### PR TITLE
Add agentic workflow scaffolding and process learnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report a reproducible defect in the editor or agent operating layer.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug in one or two sentences.
+      placeholder: The export dialog closes before download begins.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: List exact steps to reproduce the bug.
+      placeholder: |
+        1. Open /editor
+        2. Select WEBM export
+        3. Click Export
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, and any relevant local setup.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose new product, workflow, or automation behavior.
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What outcome are you trying to achieve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the desired feature or workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: What would make this complete?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Constraints or scope notes
+      description: List non-goals, constraints, or rollout notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+## Linked Issues
+
+## Root Cause
+
+## Debugging Steps
+
+## Validation
+
+- [ ] `npm run test:ci`
+- [ ] `CHANGELOG.md` updated or `skip-changelog` label requested
+
+## Notes For Reviewers
+
+- Issue classification completed
+- Relevant skill used from `agent/skills/`
+- Tests added or updated
+- GitHub issue updated with bug summary, fix summary, validation, and PR link

--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -1,0 +1,33 @@
+name: Bug Triage
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    if: github.event.label.name == 'bug'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post bug triage checklist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const body = [
+              "Bug triage checklist:",
+              "",
+              "- Run `agent/skills/triage_bug.md`.",
+              "- Confirm the affected subsystem.",
+              "- Propose the narrowest fix.",
+              "- Identify regression tests before implementation."
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body
+            });

--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,0 +1,46 @@
+name: Changelog Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce changelog updates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map((label) => label.name);
+            if (labels.includes("skip-changelog")) {
+              core.info("skip-changelog label present.");
+              return;
+            }
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              }
+            );
+
+            const changed = files.map((file) => file.filename);
+            const touchesTrackedAreas = changed.some((file) =>
+              file.startsWith("src/") ||
+              file.startsWith("agent/") ||
+              file.startsWith(".github/")
+            );
+            const touchesChangelog = changed.includes("CHANGELOG.md");
+
+            if (touchesTrackedAreas && !touchesChangelog) {
+              core.setFailed("Tracked source, agent, or GitHub workflow changes require a CHANGELOG.md update or a skip-changelog label.");
+            }

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -1,0 +1,33 @@
+name: Issue Intake
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  intake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post intake guidance
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const body = [
+              "Issue intake checklist:",
+              "",
+              "- Run `agent/skills/read_issue.md`.",
+              "- Classify the issue as Feature, Bug, Documentation, or Refactor.",
+              "- Record priority and affected components.",
+              "- Route feature work to `agent/skills/plan_feature.md`.",
+              "- Route bug work to `agent/skills/triage_bug.md`."
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body
+            });

--- a/.github/workflows/post-merge-changelog.yml
+++ b/.github/workflows/post-merge-changelog.yml
@@ -1,0 +1,58 @@
+name: Post Merge Changelog
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  follow-up:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check merged PR for changelog coverage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              }
+            );
+
+            const changed = files.map((file) => file.filename);
+            const touchesTrackedAreas = changed.some((file) =>
+              file.startsWith("src/") ||
+              file.startsWith("agent/") ||
+              file.startsWith(".github/")
+            );
+
+            if (!touchesTrackedAreas || changed.includes("CHANGELOG.md")) {
+              core.info("CHANGELOG.md updated in merged PR.");
+              return;
+            }
+
+            const title = `Changelog follow-up for merged PR #${pr.number}`;
+            const body = [
+              "A merged PR changed tracked repository files without updating `CHANGELOG.md`.",
+              "",
+              `Merged PR: #${pr.number} ${pr.title}`,
+              "",
+              "Run `agent/skills/write_changelog.md` and update the topmost version section."
+            ].join("\n");
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body
+            });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,47 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Publish PR review summary
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              "PR review automation completed.",
+              "",
+              "- Use `agent/skills/analyze_pr.md` for the review structure.",
+              "- Confirm architecture impact is acceptable.",
+              "- Confirm tests cover changed behavior.",
+              "- Verify `CHANGELOG.md` is updated when required."
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 out
 .DS_Store
+*.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Agent Operating Guide
+
+You are an AI coding agent operating inside the Dioscuri Brand Motion Toolkit repository.
+
+## Repository Context
+
+- Application: Dioscuri Brand Motion Toolkit
+- Stack: Next.js, React, TypeScript, Tailwind CSS, Zustand, Canvas/WebGL-style rendering
+- Main editor code lives under `src/`
+- Agent operating assets live under `agent/`
+
+## Responsibilities
+
+- implement features
+- fix bugs
+- review pull requests
+- write tests
+- maintain documentation
+- update changelogs
+
+## Required Workflow
+
+Before implementing code changes:
+
+1. Identify request type: feature, bug, refactor, or documentation.
+2. Invoke the appropriate skill from `agent/skills/`.
+3. Generate a structured plan.
+4. Create a branch named `codex/GENGARVIS-###-short-slug`.
+5. Implement the minimal change set.
+6. Add or update tests.
+7. Update `CHANGELOG.md`.
+8. If work is ready for review, comment on the linked GitHub issue with the bug summary, root cause, validation, and PR link.
+9. After the work closes, record workflow learnings and skill updates in `agent/memory/`.
+
+## Guardrails
+
+- Follow the development workflow defined in `agent/`.
+- Never modify unrelated modules unless required.
+- Preserve the current modular architecture.
+- Prefer extending existing `src/lib/*` modules over duplicating logic.
+- Update `agent/memory/` when a design decision, durable feature record, or known issue changes.
+- Keep changes reviewable and aligned with the current editor behavior unless the request explicitly changes behavior.
+- Pull requests must include the debugging steps and notes that led to the fix.
+
+## Branch Naming
+
+- Use `codex/GENGARVIS-###-short-slug` for active work branches.
+- Use the GitHub issue number when available, padded to three digits.
+- Keep the slug short and outcome-oriented.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+This changelog tracks notable repository changes. Add new entries to the topmost version section unless the package version is explicitly bumped.
+
+## Version 0.1.0
+
+### Added
+
+- Agent operating layer scaffolding under `agent/`
+- GitHub workflow and issue/PR templates for agentic development
+- Vitest and React Testing Library scaffolding for store, render, preset, and export coverage
+- A reusable issue-comment skill and workflow reflection memory for future issue work
+
+### Changed
+
+- Introduced test-oriented motion helpers without changing editor behavior
+- Branch naming, PR templates, and skills now capture debugging steps, issue updates, and workflow reflection requirements
+
+### Fixed
+
+- Preview rendering now uses the same logical composition dimensions as export, eliminating layout mismatches like overflowing preview text that exported correctly
+- Centered and bottom-anchored typography is now positioned from measured text-block height instead of fixed offsets, keeping live preview placement representative for large headlines
+
+### Removed
+
+- N/A

--- a/agent/memory/design_decisions.md
+++ b/agent/memory/design_decisions.md
@@ -1,0 +1,17 @@
+# Design Decisions
+
+## Rendering Stack
+
+- The editor uses a canvas-first rendering pipeline instead of Three.js to keep export behavior predictable and the runtime simpler.
+
+## State Management
+
+- The editor state is managed through a single Zustand store in `src/lib/store/editorStore.ts`.
+
+## Export Strategy
+
+- PNG and WEBM exports are performed in-browser to avoid backend rendering infrastructure.
+
+## Agent Layer
+
+- The agent operating layer is repository-native, GitHub-integrated, and documented in-tree rather than delegated to an external AI orchestration service.

--- a/agent/memory/feature_registry.md
+++ b/agent/memory/feature_registry.md
@@ -1,0 +1,29 @@
+# Feature Registry
+
+## Editor Canvas
+
+- Canvas stage with live composition preview and safe-margin/grid overlays.
+
+## Background Types
+
+- Radial glow
+- Linear wash
+- Dual orb
+- Mesh field
+
+## Motif System
+
+- Configurable motif type, count, scale, opacity, blur, position, rotation, and color.
+
+## Typography Controls
+
+- Layout presets, alignment, anchor placement, sizing, copy, and padding controls.
+
+## Preset System
+
+- Default presets and local preset persistence built on the editor store.
+
+## Export
+
+- PNG still export
+- WEBM motion export

--- a/agent/memory/known_issues.md
+++ b/agent/memory/known_issues.md
@@ -1,0 +1,5 @@
+# Known Issues
+
+- No ESLint configuration is currently checked in, so `next lint` becomes interactive in this repository state.
+- Browser APIs used by export flows require mocks in unit and component tests.
+- Stale `.next` artifacts can pollute local type checks and should not be treated as source files.

--- a/agent/memory/workflow_learnings.md
+++ b/agent/memory/workflow_learnings.md
@@ -1,0 +1,36 @@
+# Workflow Learnings
+
+## Issue 1: Preview vs Export Typography Parity
+
+### What Worked
+
+- Extracting pure sizing and typography layout helpers made the preview/export mismatch easier to isolate.
+- Regression tests on the helper layer and preview component made the final fix safer.
+- A temporary query-flag debug overlay was effective for validating wrapped lines, text block height, and anchor placement.
+
+### What Slowed Us Down
+
+- The first pass targeted shared sizing only; the typography anchor calculation also needed to move from fixed offsets to measured block height.
+- Without an issue-comment step and explicit PR debugging notes, the reasoning trail was harder to preserve than the code diff itself.
+
+### Skill Updates Needed
+
+- `triage_bug` should call out preview/export parity checks, text metrics, and font-loading state for canvas typography bugs.
+- `generate_tests` should recommend extracting pure layout helpers when direct canvas assertions are brittle.
+- A dedicated issue-comment skill is useful once work is ready for review.
+
+### Workflow Updates Needed
+
+- Branches should use `codex/GENGARVIS-###-short-slug`.
+- PRs should include root cause and debugging steps.
+- Issue-linked work should add a GitHub issue comment before or at PR creation.
+- After merge, add a short workflow reflection in `agent/memory/`.
+
+### Reusable Debugging Pattern
+
+1. Reproduce the mismatch with the smallest possible example.
+2. Compare preview and export in the same logical render space.
+3. Extract layout math into pure helpers.
+4. Add temporary diagnostics behind a query flag if needed.
+5. Convert the discovered invariants into tests.
+6. Remove the temporary diagnostics UI and keep the tests.

--- a/agent/skills/analyze_pr.md
+++ b/agent/skills/analyze_pr.md
@@ -1,0 +1,51 @@
+# Skill: analyze_pr
+
+## Purpose
+
+Use this skill to review pull requests for correctness, architectural fit, and testing coverage.
+
+## Invoke When
+
+- a pull request is opened, synchronized, or reopened
+- a review summary is needed after implementation
+
+## Required Inputs
+
+- PR description
+- changed files
+- test results
+- linked issue context if available
+
+## Inspect First
+
+- changed files in the PR
+- `src/lib/store/editorStore.ts` when state changes exist
+- `src/lib/render/*` when render/export changes exist
+- `src/components/editor/*` when UI changes exist
+- `agent/templates/pr_review_template.md`
+
+## Steps
+
+1. Summarize the PR intent.
+2. Identify architecture impact and whether the change fits current module boundaries.
+3. Review the documented root cause and debugging steps, not just the final patch.
+4. Review code quality, correctness risks, and maintainability.
+5. Check that tests cover the changed behavior.
+6. Confirm changelog, issue comment, and documentation updates when applicable.
+7. Recommend improvements or follow-up work.
+
+## Output Contract
+
+- `PR Summary`
+- `Architecture impact`
+- `Code quality review`
+- `Debugging review`
+- `Potential risks`
+- `Test coverage analysis`
+- `Suggested improvements`
+
+## Done Criteria
+
+- findings are prioritized by severity
+- testing gaps are explicit
+- architecture concerns are concrete

--- a/agent/skills/comment_issue_update.md
+++ b/agent/skills/comment_issue_update.md
@@ -1,0 +1,50 @@
+# Skill: comment_issue_update
+
+## Purpose
+
+Use this skill when code is ready to commit or a pull request is ready, and the linked GitHub issue needs a clear status update.
+
+## Invoke When
+
+- a fix branch is ready for PR
+- a PR has been opened for a linked issue
+- an issue needs a concise summary of the bug, root cause, fix, and validation
+
+## Required Inputs
+
+- issue number or URL
+- bug or feature summary
+- root cause
+- fix summary
+- validation steps
+- PR URL if available
+
+## Inspect First
+
+- linked issue content
+- relevant diff summary
+- `agent/templates/issue_update_template.md`
+
+## Steps
+
+1. Restate the issue status in one line.
+2. Summarize the root cause in plain language.
+3. Summarize the implemented fix.
+4. List validation performed.
+5. Link the PR if one exists.
+6. Keep the comment short and useful for future readers.
+
+## Output Contract
+
+- `## Status`
+- `## Bug Summary`
+- `## Root Cause`
+- `## Fix Summary`
+- `## Validation`
+- `## Pull Request`
+
+## Done Criteria
+
+- issue comment explains what changed and why
+- validation is explicit
+- PR link is included when available

--- a/agent/skills/generate_tests.md
+++ b/agent/skills/generate_tests.md
@@ -1,0 +1,54 @@
+# Skill: generate_tests
+
+## Purpose
+
+Use this skill to add or update automated tests for code changes in the editor or agent operating layer.
+
+## Invoke When
+
+- implementation is complete
+- a PR changes behavior without sufficient tests
+- a bug fix needs regression coverage
+
+## Required Inputs
+
+- summary of changed behavior
+- impacted files
+- desired test level: unit, component, integration
+
+## Inspect First
+
+- `src/lib/store/editorStore.ts`
+- `src/lib/render/backgroundRenderer.ts`
+- `src/lib/render/sceneRenderer.ts`
+- `src/lib/render/textureRenderer.ts`
+- `src/lib/render/captureFrame.ts`
+- `src/lib/render/exportVideo.ts`
+- `src/lib/presets/defaultPresets.ts`
+- `src/components/editor/*`
+- `tests/`
+- `agent/templates/test_plan_template.md`
+
+## Steps
+
+1. Identify the behavior that changed.
+2. Select the narrowest useful test level.
+3. Prefer extracting pure sizing or layout helpers when canvas bugs are difficult to test directly.
+4. Cover state store logic when state transitions changed.
+5. Cover UI control interactions when editor controls or dialogs changed.
+6. Cover rendering parameter changes when background, texture, motif, motion, or typography logic changed.
+7. Cover export triggers when export behavior changed.
+8. Add browser API mocks only where required.
+
+## Output Contract
+
+- test file list
+- scenarios covered
+- required mocks
+- verification command
+
+## Done Criteria
+
+- tests cover the intended behavior and edge cases
+- mocks are stable and minimal
+- the suite is runnable with Vitest

--- a/agent/skills/plan_feature.md
+++ b/agent/skills/plan_feature.md
@@ -1,0 +1,60 @@
+# Skill: plan_feature
+
+## Purpose
+
+Use this skill when a request adds or expands product behavior, workflow capability, or developer tooling.
+
+## Invoke When
+
+- a GitHub issue is classified as a feature
+- a user requests new functionality
+- a request changes editor workflows, agent workflows, or repository automation
+
+## Required Inputs
+
+- feature request summary
+- acceptance criteria or success signals
+- relevant issue, PR, or user context
+
+## Inspect First
+
+- `src/lib/store/editorStore.ts`
+- `src/lib/render/backgroundRenderer.ts`
+- `src/lib/render/sceneRenderer.ts`
+- `src/lib/render/textureRenderer.ts`
+- `src/lib/render/captureFrame.ts`
+- `src/lib/render/exportVideo.ts`
+- `src/lib/presets/defaultPresets.ts`
+- `src/components/editor/*`
+- `agent/templates/feature_plan_template.md`
+
+## Steps
+
+1. Identify the request type and restate the feature in one sentence.
+2. Locate impacted state, UI, rendering, export, preset, and documentation modules.
+3. Identify whether the feature changes the editor, the repo operating layer, or both.
+4. Note required state changes in `editorStore` or related types.
+5. Note required rendering or export changes in `src/lib/render/*`.
+6. Identify tests needed for store logic, UI interactions, render behavior, and export behavior.
+7. Identify documentation and changelog updates.
+8. Assess complexity, dependencies, and rollout risks.
+9. Produce the plan using the template sections below.
+
+## Output Contract
+
+- `## Feature Summary`
+- `## User Impact`
+- `## Technical Design`
+- `## Modules Impacted`
+- `## UI Changes`
+- `## State Changes`
+- `## Rendering Changes`
+- `## Tests Required`
+- `## Risks`
+- `## Implementation Plan`
+
+## Done Criteria
+
+- impacted modules are explicitly named
+- tests and changelog work are included
+- the implementation plan is sequenced and decision-complete

--- a/agent/skills/read_issue.md
+++ b/agent/skills/read_issue.md
@@ -1,0 +1,45 @@
+# Skill: read_issue
+
+## Purpose
+
+Use this skill to classify GitHub issues before planning or implementation starts.
+
+## Invoke When
+
+- a GitHub issue is opened or edited
+- a user provides an issue-like problem statement without classification
+
+## Required Inputs
+
+- issue title
+- issue body
+- labels or metadata if available
+
+## Inspect First
+
+- issue content
+- `README.md`
+- `AGENTS.md`
+- relevant `src/components/editor/*` or `src/lib/*` modules if the issue names a subsystem
+
+## Steps
+
+1. Determine whether the issue is a feature, bug, documentation task, or refactor.
+2. Assess priority: low, medium, or high.
+3. Identify affected components or subsystems.
+4. Choose the next skill.
+
+## Output Contract
+
+- `Issue Type`
+- `Priority`
+- `Affected Components`
+- `Recommended Next Skill`
+- `Recommended Branch Name`
+
+## Done Criteria
+
+- issue type is unambiguous
+- priority is justified by impact
+- next skill is actionable
+- branch name follows `codex/GENGARVIS-###-short-slug`

--- a/agent/skills/triage_bug.md
+++ b/agent/skills/triage_bug.md
@@ -1,0 +1,55 @@
+# Skill: triage_bug
+
+## Purpose
+
+Use this skill when a bug report, regression, or production issue needs diagnosis and a fix strategy.
+
+## Invoke When
+
+- a GitHub issue is labeled `bug`
+- a user reports broken behavior
+- a PR review finds a reproducible regression
+
+## Required Inputs
+
+- bug summary and reproduction steps
+- expected behavior
+- actual behavior
+- environment details if available
+
+## Inspect First
+
+- `src/lib/store/editorStore.ts`
+- `src/lib/render/backgroundRenderer.ts`
+- `src/lib/render/sceneRenderer.ts`
+- `src/lib/render/textureRenderer.ts`
+- `src/lib/render/captureFrame.ts`
+- `src/lib/render/exportVideo.ts`
+- `src/lib/presets/defaultPresets.ts`
+- `src/components/editor/*`
+- `agent/templates/bug_triage_template.md`
+
+## Steps
+
+1. Classify the affected subsystem: state, UI, rendering, presets, export, or workflow automation.
+2. Identify likely root causes from the current architecture.
+3. Inspect the closest modules first and map the bug to a concrete code path.
+4. When preview and export diverge, compare them in the same logical coordinate space before changing control semantics.
+5. For canvas and typography bugs, inspect measured text metrics, wrapping, anchor placement, and font-loading state.
+6. Use temporary diagnostics only when needed, hide them behind a query flag or dev-only path, and remove the UI once the fix is confirmed.
+7. Propose the minimal code fix.
+8. Specify regression tests.
+
+## Output Contract
+
+- `## Bug Summary`
+- `## Possible Root Causes`
+- `## Code Areas To Inspect`
+- `## Proposed Fix`
+- `## Tests Required`
+
+## Done Criteria
+
+- likely root cause is tied to named files or functions
+- fix proposal is narrow and testable
+- regression tests are identified

--- a/agent/skills/write_changelog.md
+++ b/agent/skills/write_changelog.md
@@ -1,0 +1,42 @@
+# Skill: write_changelog
+
+## Purpose
+
+Use this skill to maintain `CHANGELOG.md` after merged work or release-prep changes.
+
+## Invoke When
+
+- a pull request is merged
+- a feature, fix, or workflow change needs release notes
+- documentation requires a changelog entry
+
+## Required Inputs
+
+- merged change summary
+- affected modules
+- version information from `package.json`
+
+## Inspect First
+
+- `CHANGELOG.md`
+- `package.json`
+- merged PR description or diff summary
+- `agent/templates/changelog_entry_template.md`
+
+## Steps
+
+1. Read the topmost version section in `CHANGELOG.md`.
+2. If `package.json` version changed, add or update the matching version heading.
+3. Otherwise update the current topmost version section.
+4. Sort each entry into `Added`, `Changed`, `Fixed`, or `Removed`.
+5. Keep entries concise and user-readable.
+
+## Output Contract
+
+- updated changelog section with categorized entries
+
+## Done Criteria
+
+- changelog is updated in the correct version section
+- entries reflect the actual merged behavior
+- unrelated categories are not modified

--- a/agent/templates/bug_triage_template.md
+++ b/agent/templates/bug_triage_template.md
@@ -1,0 +1,11 @@
+# Bug Triage Template
+
+## Bug Summary
+
+## Possible Root Causes
+
+## Code Areas To Inspect
+
+## Proposed Fix
+
+## Tests Required

--- a/agent/templates/changelog_entry_template.md
+++ b/agent/templates/changelog_entry_template.md
@@ -1,0 +1,11 @@
+# Changelog Entry Template
+
+## Version X.X.X
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed

--- a/agent/templates/feature_plan_template.md
+++ b/agent/templates/feature_plan_template.md
@@ -1,0 +1,21 @@
+# Feature Plan Template
+
+## Feature Summary
+
+## User Impact
+
+## Technical Design
+
+## Modules Impacted
+
+## UI Changes
+
+## State Changes
+
+## Rendering Changes
+
+## Tests Required
+
+## Risks
+
+## Implementation Plan

--- a/agent/templates/issue_update_template.md
+++ b/agent/templates/issue_update_template.md
@@ -1,0 +1,13 @@
+# Issue Update Template
+
+## Status
+
+## Bug Summary
+
+## Root Cause
+
+## Fix Summary
+
+## Validation
+
+## Pull Request

--- a/agent/templates/pr_review_template.md
+++ b/agent/templates/pr_review_template.md
@@ -1,0 +1,13 @@
+# PR Review Template
+
+## PR Summary
+
+## Architecture Impact
+
+## Code Quality Review
+
+## Potential Risks
+
+## Test Coverage Analysis
+
+## Suggested Improvements

--- a/agent/templates/reflection_template.md
+++ b/agent/templates/reflection_template.md
@@ -1,0 +1,11 @@
+# Reflection Template
+
+## What Worked
+
+## What Slowed Us Down
+
+## Skill Updates Needed
+
+## Workflow Updates Needed
+
+## Reusable Debugging Pattern

--- a/agent/templates/test_plan_template.md
+++ b/agent/templates/test_plan_template.md
@@ -1,0 +1,13 @@
+# Test Plan Template
+
+## Scope
+
+## Target Modules
+
+## Happy Path Scenarios
+
+## Edge Cases
+
+## Required Mocks
+
+## Verification Commands

--- a/agent/workflows/github_events.md
+++ b/agent/workflows/github_events.md
@@ -1,0 +1,73 @@
+# GitHub Event Workflow Map
+
+This repository uses GitHub events to drive a structured agentic development cycle.
+
+## Lifecycle
+
+User feedback -> GitHub Issue -> `read_issue` -> `plan_feature` or `triage_bug` -> implementation -> `generate_tests` -> Pull Request -> `analyze_pr` -> merge -> `write_changelog`
+
+Before PR creation for issue-linked work, run `comment_issue_update`.
+After merge, record learnings in `agent/memory/`.
+
+## Event: Issue Opened Or Edited
+
+- Trigger source: GitHub `issues` event on `opened` and `edited`
+- Skill: `read_issue`
+- Expected inputs: issue title, body, labels, linked screenshots or reproduction notes
+- Required output: issue type, priority, affected components, recommended next skill
+- Human or agent follow-up: route the issue to `plan_feature`, `triage_bug`, documentation work, or refactor work
+- Matching GitHub workflow file: `.github/workflows/issue-intake.yml`
+
+## Event: Issue Labeled `bug`
+
+- Trigger source: GitHub `issues` event on `labeled`
+- Skill: `triage_bug`
+- Expected inputs: bug label, issue details, reproduction steps, environment notes
+- Required output: bug summary, possible root causes, code areas to inspect, proposed fix, tests required
+- Human or agent follow-up: confirm repro and implement the narrowest fix
+- Matching GitHub workflow file: `.github/workflows/bug-triage.yml`
+
+## Event: Issue Classified As Feature
+
+- Trigger source: output from `read_issue` or manual maintainer routing
+- Skill: `plan_feature`
+- Expected inputs: accepted feature request, desired outcome, acceptance criteria
+- Required output: structured feature plan with module, test, and changelog impact
+- Human or agent follow-up: implement the planned change
+- Matching GitHub workflow file: repository process, referenced by `.github/ISSUE_TEMPLATE/feature_request.yml`
+
+## Event: Implementation Complete
+
+- Trigger source: implementation branch ready for review
+- Skill: `generate_tests`
+- Expected inputs: changed files, feature or fix summary, expected behavior
+- Required output: test coverage plan and runnable tests
+- Human or agent follow-up: open or update a pull request
+- Matching GitHub workflow file: `.github/workflows/pr-review.yml`
+
+## Event: PR Ready For Review
+
+- Trigger source: branch is committed and PR is about to be opened
+- Skill: `comment_issue_update`
+- Expected inputs: issue number, root cause, fix summary, validation, PR URL
+- Required output: a short issue comment linking the work back to the issue
+- Human or agent follow-up: open or refresh the pull request
+- Matching GitHub workflow file: repository process before PR review
+
+## Event: Pull Request Opened Or Updated
+
+- Trigger source: GitHub `pull_request` event on `opened`, `synchronize`, and `reopened`
+- Skill: `analyze_pr`
+- Expected inputs: PR body, diff, workflow results, linked issues
+- Required output: PR summary, architecture impact, code quality review, risks, test coverage analysis, suggested improvements
+- Human or agent follow-up: address findings and keep `CHANGELOG.md` current
+- Matching GitHub workflow file: `.github/workflows/pr-review.yml`
+
+## Event: Pull Request Merged
+
+- Trigger source: GitHub `pull_request` event on `closed` when merged
+- Skill: `write_changelog`
+- Expected inputs: merged PR details, changed files, version context
+- Required output: changelog update or follow-up issue if a changelog entry is missing
+- Human or agent follow-up: confirm release notes quality and log workflow learnings in `agent/memory/`
+- Matching GitHub workflow file: `.github/workflows/post-merge-changelog.yml`


### PR DESCRIPTION
## Summary
- add repository agent operating guidance, skills, templates, workflow docs, and GitHub automation scaffolding
- add ticket-style branch naming guidance using 
- add an issue-comment skill plus workflow reflection memory based on the first issue fix
- update the PR template to require root cause and debugging steps

## Root Cause
The first issue fix surfaced a gap in the workflow layer: we had code changes and tests, but we did not yet have durable repo instructions for branch naming, issue updates, debugging notes in PRs, or post-task reflection.

## Debugging Steps
- worked the first live GitHub issue end to end
- used temporary typography telemetry to compare preview and export layout behavior
- identified workflow gaps around issue comments, PR debugging notes, and post-task learnings
- encoded those learnings into the repo-level agent assets and templates

## Validation
- npm run test:ci
- reviewed staged diff to ensure only agentic workflow files are included in this PR

## Notes For Reviewers
- this PR intentionally excludes the already-merged issue #1 code fix
- the new  skill is intended for issue-linked work once a branch is ready for PR