### PR TITLE
GENGARVIS-005: fix center-left and center-right anchor bleed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 - Preview rendering now uses the same logical composition dimensions as export, eliminating layout mismatches like overflowing preview text that exported correctly
 - Centered and bottom-anchored typography is now positioned from measured text-block height instead of fixed offsets, keeping live preview placement representative for large headlines
+- Center-left and center-right anchors now respect their horizontal safe margins instead of centering text off the working area
 
 ### Removed
 

--- a/src/lib/render/sceneRenderer.ts
+++ b/src/lib/render/sceneRenderer.ts
@@ -165,7 +165,7 @@ function applyTextAlign(
   alignment: TextAlignment,
   anchor: AnchorPosition
 ) {
-  if (alignment === 'center' || anchor.includes('center')) {
+  if (alignment === 'center' || anchor === 'center' || anchor.endsWith('center')) {
     ctx.textAlign = 'center';
     return;
   }

--- a/tests/typographyLayout.test.ts
+++ b/tests/typographyLayout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createDocument } from '@/lib/presets/defaultPresets';
+import { drawScene } from '@/lib/render/sceneRenderer';
 import { createTypographyLayout } from '@/lib/render/typographyLayout';
 import { asCanvasContext, createMockCanvasContext } from './testUtils';
 
@@ -55,5 +56,25 @@ describe('typographyLayout', () => {
     );
 
     expect(layout.startY).toBeLessThan(1080 - 112);
+  });
+
+  it.each([
+    ['center-left', 'left'],
+    ['center', 'center'],
+    ['center-right', 'right'],
+    ['top-center', 'center'],
+    ['bottom-center', 'center']
+  ] as const)('uses %s anchor with %s horizontal alignment', (anchor, expectedAlign) => {
+    const context = createMockCanvasContext();
+    const document = createDocument();
+    document.typography.anchor = anchor;
+    document.typography.alignment = 'left';
+    document.motion.enabled = false;
+
+    drawScene(asCanvasContext(context), 1920, 1080, document, {
+      elapsedSeconds: 0
+    });
+
+    expect(context.textAlign).toBe(expectedAlign);
   });
 });


### PR DESCRIPTION
## Summary

- fix horizontal alignment for side-center anchors so text stays inside the working area
- add typography alignment regressions for `center-left`, `center-right`, and center-column anchors
- document the fix in `CHANGELOG.md`

## Linked Issues

- Closes #5

## Root Cause

The renderer treated any anchor containing the word `center` as centered text. That made `center-left` and `center-right` use centered alignment from the safe-margin origin, which pushed text beyond the left or right working edge in both preview and export.

## Debugging Steps

- inspected `sceneRenderer` and `typographyLayout` to compare anchor origin and text alignment behavior
- confirmed the bug affected both preview and export because both use the same scene renderer
- narrowed the fix to the alignment fallback instead of changing anchor positions or safe-margin math

## Validation

- [x] `npm run test:ci -- tests/typographyLayout.test.ts tests/canvasStage.test.tsx`
- [x] `CHANGELOG.md` updated or `skip-changelog` label requested

## Notes For Reviewers

- this PR is intentionally narrow and only addresses issue #5
- merge after PR #7 so the workflow changes land first and the changelog sequence stays cleaner
