### PR TITLE
GENGARVIS-004: preserve typography when toggling background-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 - Preview rendering now uses the same logical composition dimensions as export, eliminating layout mismatches like overflowing preview text that exported correctly
 - Centered and bottom-anchored typography is now positioned from measured text-block height instead of fixed offsets, keeping live preview placement representative for large headlines
 - Center-left and center-right anchors now respect their horizontal safe margins instead of centering text off the working area
+- Switching through the Background Only layout preset no longer deletes typography content, while still hiding text output for that preset
 
 ### Removed
 

--- a/src/lib/render/sceneRenderer.ts
+++ b/src/lib/render/sceneRenderer.ts
@@ -190,6 +190,10 @@ function drawTypography(
   height: number,
   document: BrandDocument
 ) {
+  if (document.layoutPreset === 'background-only') {
+    return;
+  }
+
   const paddingMap = {
     sm: 52,
     md: 76,

--- a/src/lib/store/editorStore.ts
+++ b/src/lib/store/editorStore.ts
@@ -81,9 +81,6 @@ function applyLayoutPreset(
       next.motif.position = { x: 0.72, y: 0.22 };
       break;
     case 'background-only':
-      next.typography.eyebrow = '';
-      next.typography.headline = '';
-      next.typography.body = '';
       break;
     case 'editorial-top-left':
     default:

--- a/tests/editorStore.test.ts
+++ b/tests/editorStore.test.ts
@@ -38,6 +38,23 @@ describe('editorStore', () => {
     expect(state.document.motif.position).toEqual({ x: 0.8, y: 0.3 });
   });
 
+  it('preserves typography content when toggling through background-only', () => {
+    const store = useEditorStore.getState();
+    const originalTypography = { ...store.document.typography };
+
+    store.setLayoutPreset('background-only');
+    let state = useEditorStore.getState();
+    expect(state.document.typography.eyebrow).toBe(originalTypography.eyebrow);
+    expect(state.document.typography.headline).toBe(originalTypography.headline);
+    expect(state.document.typography.body).toBe(originalTypography.body);
+
+    store.setLayoutPreset('editorial-top-left');
+    state = useEditorStore.getState();
+    expect(state.document.typography.eyebrow).toBe(originalTypography.eyebrow);
+    expect(state.document.typography.headline).toBe(originalTypography.headline);
+    expect(state.document.typography.body).toBe(originalTypography.body);
+  });
+
   it('supports save, duplicate, load, and delete preset flows', () => {
     const store = useEditorStore.getState();
     const initialCount = store.presets.length;

--- a/tests/typographyLayout.test.ts
+++ b/tests/typographyLayout.test.ts
@@ -83,4 +83,17 @@ describe('typographyLayout', () => {
     expect(context.fillText).toHaveBeenCalledWith('Hello', expectedX, expect.any(Number));
   }
   );
+
+  it('skips typography drawing for the background-only layout preset', () => {
+    const context = createMockCanvasContext();
+    const document = createDocument();
+    document.layoutPreset = 'background-only';
+    document.motion.enabled = false;
+
+    drawScene(asCanvasContext(context), 1920, 1080, document, {
+      elapsedSeconds: 0
+    });
+
+    expect(context.fillText).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- preserve typography copy when the Background Only layout preset is selected
- hide typography rendering for the Background Only preset instead of deleting the stored text
- add store and renderer regressions for the preset transition

## Linked Issues

- Closes #4

## Root Cause

The layout preset transition for `background-only` mutated the document by clearing eyebrow, headline, and body copy. That made the preset act like a destructive delete instead of a display toggle, so switching back to editorial layouts could not restore the text.

## Debugging Steps

- inspected `editorStore.applyLayoutPreset` to trace how preset changes mutate document state
- confirmed the deletion happened in store state rather than only in rendering
- moved the behavior to rendering so the preset can hide typography output without destroying the source copy

## Validation

- [x] `npm run test:ci -- tests/editorStore.test.ts tests/typographyLayout.test.ts tests/canvasStage.test.tsx`
- [x] `CHANGELOG.md` updated or `skip-changelog` label requested

## Notes For Reviewers

- this PR is intentionally narrow and only addresses issue #4
- merge after PR #7 and after PR #8 so the fix stream stays one issue per PR
