### PR TITLE
Create shared studio shell and toolkit registry contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 ### Added
 
+- Shared studio-shell launcher and typed toolkit registry contract for suite entry-point routing
+- Focused launcher coverage for the shared toolkit registry and planned-versus-live card behavior
 - Agent operating layer scaffolding under `agent/`
 - Codex multi-agent runtime scaffold under `.codex/`, `agents/`, and `skills.md`
 - A dedicated `browser_screenshot` sub-agent contract for PR-ready frontend visual QA artifacts
@@ -16,6 +18,8 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 ### Changed
 
+- The root landing page now renders a suite launcher from shared registry data instead of redirecting directly into the motion editor
+- Added package path aliases and Next.js tracing support needed for the shared launcher contract
 - Introduced test-oriented motion helpers without changing editor behavior
 - Branch naming, PR templates, and skills now capture debugging steps, issue updates, and workflow reflection requirements
 - Frontend workflow guidance now treats browser screenshots as soft-required PR-prep artifacts when tooling is available

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
+import path from 'node:path';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  typedRoutes: true
+  typedRoutes: true,
+  outputFileTracingRoot: path.join(__dirname)
 };
 
 export default nextConfig;

--- a/packages/studio-shell/src/ToolkitLauncher.tsx
+++ b/packages/studio-shell/src/ToolkitLauncher.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import type { ToolkitDefinition } from './types';
+
+export function ToolkitLauncher({
+  title,
+  subtitle,
+  toolkits
+}: {
+  title: string;
+  subtitle: string;
+  toolkits: ToolkitDefinition[];
+}) {
+  return (
+    <main className="min-h-screen px-4 py-6 text-fog md:px-6">
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-[1440px] flex-col gap-6 rounded-[32px] border border-white/8 bg-white/[0.03] p-5 shadow-panel">
+        <header className="panel-surface rounded-[28px] px-5 py-6">
+          <p className="text-[11px] uppercase tracking-[0.34em] text-white/42">Dioscuri Platform</p>
+          <h1 className="mt-3 font-display text-4xl text-fog md:text-5xl">{title}</h1>
+          <p className="mt-3 max-w-3xl text-sm text-white/62 md:text-base">{subtitle}</p>
+        </header>
+        <section className="grid gap-4 lg:grid-cols-3">
+          {toolkits.map((toolkit) =>
+            toolkit.status === 'live' && toolkit.href ? (
+              <Link
+                className="panel-surface rounded-[28px] p-5 transition hover:-translate-y-0.5 hover:border-white/18"
+                href={toolkit.href}
+                key={toolkit.id}
+              >
+                <ToolkitCardContent toolkit={toolkit} />
+              </Link>
+            ) : (
+              <article
+                className="panel-surface rounded-[28px] border border-white/6 p-5 opacity-80"
+                key={toolkit.id}
+              >
+                <ToolkitCardContent toolkit={toolkit} />
+              </article>
+            )
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function ToolkitCardContent({ toolkit }: { toolkit: ToolkitDefinition }) {
+  const statusLabel = toolkit.status === 'live' ? 'Live' : 'Planned';
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.22em] text-white/46">{statusLabel}</p>
+        <span className="rounded-full border border-white/10 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-white/54">
+          {toolkit.capabilities.map((capability) => capability.label).join(' / ')}
+        </span>
+      </div>
+      <h2 className="mt-6 font-display text-3xl text-fog">{toolkit.label}</h2>
+      <p className="mt-3 text-sm leading-6 text-white/62">{toolkit.summary}</p>
+    </>
+  );
+}

--- a/packages/studio-shell/src/types.ts
+++ b/packages/studio-shell/src/types.ts
@@ -1,0 +1,15 @@
+import type { Route } from 'next';
+
+export type ToolkitCapability = {
+  id: string;
+  label: string;
+};
+
+export type ToolkitDefinition = {
+  id: 'motion-toolkit' | 'dataviz-toolkit' | 'social-card-toolkit';
+  label: string;
+  summary: string;
+  href?: Route;
+  status: 'live' | 'planned';
+  capabilities: ToolkitCapability[];
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from 'next';
 import '@/styles/globals.css';
 
 export const metadata: Metadata = {
-  title: 'Dioscuri Brand Motion Toolkit',
-  description: 'Constrained editor for cinematic branded stills and looping motion.'
+  title: 'Dioscuri Brand Toolkit Suite',
+  description: 'Shared platform for motion scenes, branded dataviz, and social publishing templates.'
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,12 @@
-import { redirect } from 'next/navigation';
+import { ToolkitLauncher } from '@packages/studio-shell/src/ToolkitLauncher';
+import { toolkitRegistry } from '@/lib/toolkits';
 
 export default function HomePage() {
-  redirect('/editor');
+  return (
+    <ToolkitLauncher
+      title="Brand Toolkit Suite"
+      subtitle="A shared internal platform for branded motion scenes, editorial data visualization, and social publishing templates."
+      toolkits={toolkitRegistry}
+    />
+  );
 }

--- a/src/lib/toolkits.ts
+++ b/src/lib/toolkits.ts
@@ -1,0 +1,35 @@
+import type { ToolkitDefinition } from '@packages/studio-shell/src/types';
+
+export const toolkitRegistry: ToolkitDefinition[] = [
+  {
+    id: 'motion-toolkit',
+    label: 'Motion Toolkit',
+    summary: 'Canvas-based branded still and motion scenes with presets, overlays, and in-browser export.',
+    href: '/editor',
+    status: 'live',
+    capabilities: [
+      { id: 'motion-png', label: 'PNG' },
+      { id: 'motion-webm', label: 'WEBM' }
+    ]
+  },
+  {
+    id: 'dataviz-toolkit',
+    label: 'Data Visualization Toolkit',
+    summary: 'Structured chart workflows will launch here once the shared shell and toolkit contracts are in place.',
+    status: 'planned',
+    capabilities: [
+      { id: 'dataviz-data', label: 'CSV / JSON' },
+      { id: 'dataviz-chart', label: 'Chart Templates' }
+    ]
+  },
+  {
+    id: 'social-card-toolkit',
+    label: 'Social Card Toolkit',
+    summary: 'Constrained social publishing templates will plug into the same launcher once the toolkit bootstrap lands.',
+    status: 'planned',
+    capabilities: [
+      { id: 'social-svg', label: 'SVG / PNG' },
+      { id: 'social-templates', label: 'Template Cards' }
+    ]
+  }
+];

--- a/tests/toolkitLauncher.test.tsx
+++ b/tests/toolkitLauncher.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ToolkitLauncher } from '@packages/studio-shell/src/ToolkitLauncher';
+import { toolkitRegistry } from '@/lib/toolkits';
+
+describe('ToolkitLauncher', () => {
+  it('lists all suite toolkits from the shared registry', () => {
+    render(
+      <ToolkitLauncher
+        title="Brand Toolkit Suite"
+        subtitle="Shared platform"
+        toolkits={toolkitRegistry}
+      />
+    );
+
+    expect(screen.getByText('Motion Toolkit')).toBeInTheDocument();
+    expect(screen.getByText('Data Visualization Toolkit')).toBeInTheDocument();
+    expect(screen.getByText('Social Card Toolkit')).toBeInTheDocument();
+  });
+
+  it('links only the live motion toolkit card', () => {
+    render(
+      <ToolkitLauncher
+        title="Brand Toolkit Suite"
+        subtitle="Shared platform"
+        toolkits={toolkitRegistry}
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', '/editor');
+    expect(screen.getAllByText('Planned')).toHaveLength(2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,9 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@apps/*": ["apps/*"],
+      "@packages/*": ["packages/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src')
+      '@': path.resolve(__dirname, 'src'),
+      '@apps': path.resolve(__dirname, 'apps'),
+      '@packages': path.resolve(__dirname, 'packages')
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- add a shared `studio-shell` launcher component and typed toolkit registry contract
- replace the root redirect with a suite landing page rendered from shared registry data
- keep only the motion toolkit live and render dataviz/social cards as planned, non-clickable entries

## Linked Issues
- Closes #22

## Root Cause
- the root app was hard-coded to redirect straight into `/editor`
- toolkit metadata was not modeled in a reusable contract, so the suite could not expose a shared launcher without widening into app-specific logic

## Debugging Steps
- inspected the suite epic and issue scaffolding to recover the intended thin-slice order
- isolated the minimal launcher files from broader local suite WIP so the PR stays scoped to `#22`
- verified the launcher behavior against the current motion entry point and planned-card expectations

## Validation
- [x] `npm run test:ci`
- [x] `npm run lint`
- [x] `CHANGELOG.md` updated or `skip-changelog` label requested
- [x] `npm run build`

## Visual Validation
- Screenshot artifacts or local paths:
  - `/var/folders/qv/lzvwghms5n16ch2sdwhst9g00000gn/T/codex-shot-2026-03-15_12-46-30-w124.png`
- Browser tooling used, terminal/app capture method, or skip reason:
  - Google Chrome opened against `http://localhost:3000`, then captured with the screenshot skill's macOS helper
- What the screenshot proves:
  - the landing page renders the shared launcher, shows Motion Toolkit as live, and shows Data Visualization Toolkit plus Social Card Toolkit as planned cards
- Visual QA summary:
  - launcher layout renders correctly with status labels and capability chips; no obvious layout regressions on the reviewed state

## Notes For Reviewers
- Issue classification completed
- Relevant skill used from `agent/skills/`: `plan_feature`, `comment_issue_update`
- Tests added or updated
- GitHub issue updated with bug summary, fix summary, validation, and PR link
- Frontend-affecting work includes screenshot evidence or a documented skip reason
