### PR TITLE
Cycle 2: ship the Data Visualization Toolkit MVP

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,7 +12,7 @@ description = "Read-only codebase explorer for locating architecture seams, reus
 config_file = "../agents/explorer.toml"
 
 [agents.design_guardian]
-description = "Design system reviewer that enforces tokens, themes, spacing, palette behavior, and reusable UI primitives while flagging likely visual regressions."
+description = "Design system reviewer that enforces tokens, themes, spacing, palette behavior, reusable UI primitives, and review-driven visual polish passes."
 config_file = "../agents/design-guardian.toml"
 
 [agents.frontend_architect]
@@ -32,7 +32,7 @@ description = "UI debugger that runs the product, captures repro steps, inspects
 config_file = "../agents/browser-debugger.toml"
 
 [agents.browser_screenshot]
-description = "Browser screenshot specialist that captures feature states, flags obvious visual regressions, and returns artifact paths plus proof notes for PR prep."
+description = "Browser screenshot specialist that captures feature states, flags obvious visual regressions, and returns artifact paths plus proof notes or an immediate skip reason for PR prep."
 config_file = "../agents/browser-screenshot.toml"
 
 [agents.docs_writer]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 ### Added
 
+- A shared-shell Data Visualization Toolkit route with guided data mapping, saveable dataviz presets, annotation fields, and output-preset-driven SVG/PNG export
+- Dataviz validation helpers for multi-series and scatter-chart mapping requirements
+- A shared collapsible control-section primitive for dropdown-style editor panes
 - Shared studio-shell launcher and typed toolkit registry contract for suite entry-point routing
 - Focused launcher coverage for the shared toolkit registry and planned-versus-live card behavior
 - Agent operating layer scaffolding under `agent/`
@@ -27,6 +30,8 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 ### Changed
 
+- The Data Visualization Toolkit now uses dropdown edit panes, standard 4:5/16:9/1:1 output presets, editable palette overrides, always-on cartesian axes, legend placement under the subheadline, fitted header copy, and a centered Big Number layout
+- Skill guidance and tracked agent profiles now treat maintainer review notes as structured QA input and require immediate screenshot skip reasons when capture tooling is blocked
 - The root landing page now renders a suite launcher from shared registry data instead of redirecting directly into the motion editor
 - Added package path aliases and Next.js tracing support needed for the shared launcher contract
 - Introduced test-oriented motion helpers without changing editor behavior

--- a/agent/memory/workflow_learnings.md
+++ b/agent/memory/workflow_learnings.md
@@ -167,3 +167,35 @@
 3. Validate the package entry point and the compatibility layer together.
 4. Commit one clean checkpoint per issue inside the cycle branch.
 5. Leave unrelated WIP parked until the PR sweep classifies it.
+
+## Issue 15: Dataviz Review Polish
+
+### What Worked
+
+- A maintainer-provided visual bug list was enough to drive a focused polish pass without reopening discovery from scratch.
+- Converting review notes into renderer-level regression tests kept typography fitting, legend placement, axes, and big-number layout from drifting again.
+- Reusing the shared shell while adding a reusable collapsible section kept the app-specific fix from becoming a one-off UI pattern.
+
+### What Slowed Us Down
+
+- The screenshot pass stalled when capture could not complete cleanly, which delayed handoff despite the rest of the validation already being green.
+- Visual review fixes touched both editor controls and SVG layout, so the implementation map had to be restated before coding resumed.
+
+### Skill Updates Needed
+
+- `skills.md` should route review-driven polish passes through `design_guardian` before implementation.
+- `browser_screenshot` guidance should explicitly require an immediate skip reason when capture is blocked or interrupted.
+
+### Workflow Updates Needed
+
+- Treat maintainer review notes as first-class QA evidence, not just as ad-hoc comments.
+- Convert accepted review findings into focused regression tests during the same pass whenever feasible.
+- Record screenshot skips quickly so PR prep is not blocked on tooling timeouts.
+
+### Reusable Delivery Pattern
+
+1. Turn reviewed bugs into a concrete implementation checklist.
+2. Map each note to the current shell, renderer, or contract layer before editing.
+3. Fix shared geometry or UI primitives before patching template-specific symptoms.
+4. Add regression tests for each review finding that can be expressed deterministically.
+5. Capture browser evidence or record an explicit skip reason immediately.

--- a/agents/browser-screenshot.toml
+++ b/agents/browser-screenshot.toml
@@ -1,4 +1,4 @@
-# Expected output: artifact paths, captured states, capture method, what each image proves, or a concrete skip reason.
+# Expected output: artifact paths, captured states, capture method, what each image proves, or a concrete skip reason returned immediately if capture is blocked or interrupted.
 # Preferred capture backend: Chrome DevTools MCP server when available.
 # Fallback: OS-level `screencapture` with a documented skip reason if the browser window cannot be targeted.
 model = "gpt-5"

--- a/agents/design-guardian.toml
+++ b/agents/design-guardian.toml
@@ -1,4 +1,4 @@
-# Expected output: tokens or palettes touched, spacing or shell concerns, and a shortlist of visual regressions to verify later.
+# Expected output: tokens or palettes touched, spacing or shell concerns, maintainer-review polish risks, and a shortlist of visual regressions to verify later.
 model = "gpt-5"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"

--- a/apps/dataviz-toolkit/src/DatavizToolkitPage.tsx
+++ b/apps/dataviz-toolkit/src/DatavizToolkitPage.tsx
@@ -1,34 +1,50 @@
 'use client';
 
 import { useDeferredValue, useMemo, useState } from 'react';
-import { chartTemplateDefinitions } from '@packages/chart-core/src/templates';
-import { inferNumericColumns, parseDatasetInput } from '@packages/chart-core/src/parser';
+import { datasetToDelimitedText, inferNumericColumns, parseDatasetInput } from '@packages/chart-core/src/parser';
 import { renderChartSvg } from '@packages/chart-core/src/renderSvg';
-import { brandThemes, themePassesContrastGuidance } from '@packages/design-tokens/src/colors';
+import { getChartTemplateDefinition, chartTemplateDefinitions } from '@packages/chart-core/src/templates';
+import { getDatavizValidationMessages } from '@packages/chart-core/src/validation';
+import {
+  brandThemes,
+  themePassesContrastGuidance,
+  type ThemeDefinition
+} from '@packages/design-tokens/src/colors';
 import type {
   DatavizDataset,
   DatavizFieldMapping,
+  DatavizOptions,
   DatavizTemplate,
+  DatavizToolkitDocument,
   SuiteAspectRatio
 } from '@packages/config-schema/src/document';
+import { suiteExportCapabilities } from '@packages/export-engine/src/contracts';
 import { downloadBlob, svgMarkupToBlob, svgMarkupToPngBlob } from '@packages/export-engine/src/svgExport';
-import { loadStoredValue, saveStoredValue } from '@packages/studio-shell/src/presetStorage';
+import { BrandedHeader } from '@packages/studio-shell/src/BrandedHeader';
+import { EditorShell } from '@packages/studio-shell/src/EditorShell';
+import { getOutputPreset } from '@packages/studio-shell/src/outputPresets';
+import { loadVersionedStoredValue, saveVersionedStoredValue } from '@packages/studio-shell/src/presetStorage';
+import { PreviewSurface } from '@packages/studio-shell/src/PreviewSurface';
+import { CollapsibleSection } from '@packages/ui/src/CollapsibleSection';
 import { SurfaceCard } from '@packages/ui/src/SurfaceCard';
+import { ColorTokenPicker } from '@packages/ui/src/controls/ColorTokenPicker';
+import { SelectField } from '@packages/ui/src/controls/SelectField';
+import { ToggleField } from '@packages/ui/src/controls/ToggleField';
 
 const STORAGE_KEY = 'dioscuri-dataviz-presets-v1';
-
-type DatavizPreset = {
-  id: string;
-  name: string;
-  template: DatavizTemplate;
-  aspectRatio: SuiteAspectRatio;
-  themeId: string;
-  inputMode: 'csv' | 'table' | 'json';
-  rawInput: string;
-  mapping: DatavizFieldMapping;
-  headline: string;
-  subheadline: string;
-  source: string;
+const STORAGE_VERSION = 1;
+const DATAVIZ_OUTPUT_PRESET_IDS = ['portrait-4x5', 'landscape-16x9', 'square-1080'] as const;
+const DATAVIZ_OUTPUT_PRESETS = DATAVIZ_OUTPUT_PRESET_IDS
+  .map((presetId) => getOutputPreset(presetId))
+  .filter((preset): preset is NonNullable<ReturnType<typeof getOutputPreset>> => Boolean(preset));
+const DEFAULT_OUTPUT_PRESET_ID = DATAVIZ_OUTPUT_PRESETS[0]?.id ?? 'portrait-4x5';
+const DEFAULT_OPTIONS: DatavizOptions = {
+  showGrid: true,
+  showLegend: true,
+  animate: false,
+  highlightSeries: undefined,
+  useCustomPalette: false,
+  customPalette: []
 };
 
 function createId(prefix: string) {
@@ -44,26 +60,76 @@ const emptyDataset: DatavizDataset = {
   rows: []
 };
 
+function getSuiteAspectRatioForPreset(presetId: string): SuiteAspectRatio {
+  const aspectRatio = getOutputPreset(presetId)?.aspectRatio;
+
+  if (aspectRatio === '1:1' || aspectRatio === '4:5' || aspectRatio === '16:9') {
+    return aspectRatio;
+  }
+
+  return '4:5';
+}
+
+function slugifyFilename(value: string) {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'dataviz-chart'
+  );
+}
+
+function getTheme(themeId: string) {
+  return brandThemes.find((theme) => theme.id === themeId) ?? brandThemes[0];
+}
+
+function buildPaletteSlots(theme: ThemeDefinition, options: DatavizOptions) {
+  return Array.from({ length: 4 }, (_, index) => {
+    return options.customPalette[index] ?? theme.chartPalette[index % theme.chartPalette.length];
+  });
+}
+
 export function DatavizToolkitPage() {
   const [template, setTemplate] = useState<DatavizTemplate>('bar');
-  const [aspectRatio, setAspectRatio] = useState<SuiteAspectRatio>('4:5');
+  const [outputPresetId, setOutputPresetId] = useState(DEFAULT_OUTPUT_PRESET_ID);
+  const [exportFormat, setExportFormat] = useState<'png' | 'svg'>('png');
   const [themeId, setThemeId] = useState('dark-editorial');
   const [inputMode, setInputMode] = useState<'csv' | 'table' | 'json'>('csv');
   const [rawInput, setRawInput] = useState(defaultInput);
   const [headline, setHeadline] = useState('Ridership grew across peak hours');
-  const [subheadline, setSubheadline] = useState('Morning demand recovered faster than evening demand');
+  const [subheadline, setSubheadline] = useState(
+    'Morning demand recovered faster than evening demand'
+  );
   const [source, setSource] = useState('Source: Internal analytics');
+  const [annotationsInput, setAnnotationsInput] = useState('North region reopened in March');
   const [mapping, setMapping] = useState<DatavizFieldMapping>({
     xColumn: 'Month',
     valueColumns: ['North', 'South', 'West'],
     yColumn: 'North'
   });
+  const [options, setOptions] = useState<DatavizOptions>(DEFAULT_OPTIONS);
   const [presetName, setPresetName] = useState('Peak Hours Story');
-  const [presets, setPresets] = useState<DatavizPreset[]>(() =>
-    loadStoredValue<DatavizPreset[]>(STORAGE_KEY, [])
+  const [presets, setPresets] = useState<DatavizToolkitDocument[]>(() =>
+    loadVersionedStoredValue<DatavizToolkitDocument[]>(STORAGE_KEY, STORAGE_VERSION, [])
   );
 
   const deferredInput = useDeferredValue(rawInput);
+  const aspectRatio = getSuiteAspectRatioForPreset(outputPresetId);
+  const outputPreset =
+    getOutputPreset(outputPresetId) ?? getOutputPreset(DEFAULT_OUTPUT_PRESET_ID) ?? DATAVIZ_OUTPUT_PRESETS[0];
+  const annotations = useMemo(
+    () =>
+      annotationsInput
+        .split(/\r?\n/)
+        .map((value) => value.trim())
+        .filter(Boolean),
+    [annotationsInput]
+  );
+  const templateDefinition = getChartTemplateDefinition(template);
+  const exportCapabilities = suiteExportCapabilities.dataviz;
+  const activeTheme = getTheme(themeId);
+  const editablePalette = buildPaletteSlots(activeTheme, options);
 
   const parsedInput = useMemo(() => {
     try {
@@ -80,7 +146,6 @@ export function DatavizToolkitPage() {
   }, [deferredInput, inputMode]);
 
   const { dataset, error } = parsedInput;
-
   const numericColumns = useMemo(() => inferNumericColumns(dataset), [dataset]);
 
   const resolvedMapping = useMemo<DatavizFieldMapping>(() => {
@@ -128,86 +193,117 @@ export function DatavizToolkitPage() {
         headline,
         subheadline,
         source,
-        themeId
+        themeId,
+        annotations,
+        options,
+        size: outputPreset
+          ? {
+              width: outputPreset.width,
+              height: outputPreset.height
+            }
+          : undefined
       }),
-    [aspectRatio, dataset, headline, resolvedMapping, source, subheadline, template, themeId]
+    [
+      annotations,
+      aspectRatio,
+      dataset,
+      headline,
+      options,
+      outputPreset,
+      resolvedMapping,
+      source,
+      subheadline,
+      template,
+      themeId
+    ]
   );
 
   const validationMessages = [
-    dataset.rows.length === 0 ? 'Add data to unlock a valid chart preview.' : null,
-    !resolvedMapping.xColumn ? 'Choose a category or x-axis column.' : null,
-    template !== 'big-number' && !resolvedMapping.yColumn && resolvedMapping.valueColumns.length === 0
-      ? 'Choose at least one numeric value column.'
-      : null,
-    !themePassesContrastGuidance(brandThemes.find((theme) => theme.id === themeId) ?? brandThemes[0], 3.8)
+    ...(!error
+      ? getDatavizValidationMessages({
+          dataset,
+          mapping: resolvedMapping,
+          template,
+          highlightSeries: options.highlightSeries
+        })
+      : []),
+    !themePassesContrastGuidance(activeTheme, 3.8)
       ? 'Selected theme fails the current contrast guidance.'
       : null
   ].filter(Boolean) as string[];
 
+  const exportCurrentPreview = async () => {
+    const filename = slugifyFilename(presetName);
+
+    if (exportFormat === 'svg') {
+      downloadBlob(svgMarkupToBlob(preview.svg), `${filename}.svg`);
+      return;
+    }
+
+    const blob = await svgMarkupToPngBlob(preview.svg, preview.width, preview.height);
+    downloadBlob(blob, `${filename}.png`);
+  };
+
   const savePreset = () => {
-    const nextPreset: DatavizPreset = {
-      id: createId('dataviz-preset'),
-      name: presetName.trim() || 'Untitled preset',
+    const timestamp = new Date().toISOString();
+    const nextPreset: DatavizToolkitDocument = {
+      toolkit: 'dataviz',
       template,
+      theme: themeId,
       aspectRatio,
-      themeId,
-      inputMode,
-      rawInput,
+      export: {
+        format: exportFormat,
+        filename: slugifyFilename(presetName),
+        presetId: outputPresetId
+      },
+      presetMeta: {
+        id: createId('dataviz-preset'),
+        name: presetName.trim() || 'Untitled preset',
+        createdAt: timestamp,
+        updatedAt: timestamp
+      },
+      content: {
+        headline,
+        subheadline,
+        annotations,
+        source
+      },
+      data: dataset,
       mapping: resolvedMapping,
-      headline,
-      subheadline,
-      source
+      options
     };
     const nextPresets = [nextPreset, ...presets];
     setPresets(nextPresets);
-    saveStoredValue(STORAGE_KEY, nextPresets);
+    saveVersionedStoredValue(STORAGE_KEY, STORAGE_VERSION, nextPresets);
+  };
+
+  const updateCustomPalette = (index: number, value: string) => {
+    setOptions((current) => {
+      const nextPalette = buildPaletteSlots(activeTheme, current);
+      nextPalette[index] = value;
+
+      return {
+        ...current,
+        useCustomPalette: true,
+        customPalette: nextPalette
+      };
+    });
   };
 
   return (
-    <main className="min-h-screen px-4 py-4 text-fog md:px-6">
-      <div className="mx-auto flex min-h-[calc(100vh-2rem)] max-w-[1680px] flex-col gap-4 rounded-[32px] border border-white/8 bg-white/[0.03] p-4 shadow-panel">
-        <SurfaceCard className="px-5 py-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <p className="text-[11px] uppercase tracking-[0.34em] text-white/42">Dataviz Toolkit</p>
-              <h1 className="mt-2 font-display text-4xl text-fog">Structured editorial charts</h1>
-              <p className="mt-3 max-w-3xl text-sm text-white/62">
-                Upload structured data, map fields into approved templates, and export a branded chart without leaving the platform.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <button
-                className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/78"
-                onClick={savePreset}
-                type="button"
-              >
-                Save Preset
-              </button>
-              <button
-                className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/78"
-                onClick={() => downloadBlob(svgMarkupToBlob(preview.svg), `${presetName || 'dataviz'}.svg`)}
-                type="button"
-              >
-                Export SVG
-              </button>
-              <button
-                className="rounded-full bg-fog px-4 py-2 text-sm font-semibold text-ink"
-                onClick={async () => {
-                  const blob = await svgMarkupToPngBlob(preview.svg, preview.width, preview.height);
-                  downloadBlob(blob, `${presetName || 'dataviz'}.png`);
-                }}
-                type="button"
-              >
-                Export PNG
-              </button>
-            </div>
-          </div>
-        </SurfaceCard>
+    <EditorShell
+      controls={
+        <div className="space-y-4 overflow-y-auto pr-1">
+          <CollapsibleSection defaultOpen title="Story">
+            <Field label="Preset Name" onChange={setPresetName} value={presetName} />
+            <Field label="Headline" onChange={setHeadline} value={headline} />
+            <TextAreaField label="Subheadline" onChange={setSubheadline} value={subheadline} />
+            <Field label="Source" onChange={setSource} value={source} />
+            <TextAreaField label="Annotations" onChange={setAnnotationsInput} value={annotationsInput} />
+          </CollapsibleSection>
 
-        <div className="grid gap-4 xl:grid-cols-[420px_minmax(0,1fr)_320px]">
-          <SurfaceCard className="space-y-4 p-4">
-            <SectionLabel title="Template" />
-            <Select
+          <CollapsibleSection defaultOpen title="Template & Output">
+            <SelectField
               label="Chart Template"
               onChange={(value) => setTemplate(value as DatavizTemplate)}
               options={chartTemplateDefinitions.map((entry) => ({
@@ -216,17 +312,25 @@ export function DatavizToolkitPage() {
               }))}
               value={template}
             />
-            <Select
-              label="Aspect Ratio"
-              onChange={(value) => setAspectRatio(value as SuiteAspectRatio)}
-              options={[
-                { value: '1:1', label: '1:1 Square' },
-                { value: '4:5', label: '4:5 Portrait' },
-                { value: '16:9', label: '16:9 Presentation' }
-              ]}
-              value={aspectRatio}
+            <SelectField
+              label="Output Preset"
+              onChange={setOutputPresetId}
+              options={DATAVIZ_OUTPUT_PRESETS.map((preset) => ({
+                value: preset.id,
+                label: `${preset.label} · ${preset.aspectRatio}`
+              }))}
+              value={outputPresetId}
             />
-            <Select
+            <SelectField
+              label="Export Format"
+              onChange={(value) => setExportFormat(value as 'png' | 'svg')}
+              options={exportCapabilities.map((capability) => ({
+                value: capability.format,
+                label: capability.label
+              }))}
+              value={exportFormat}
+            />
+            <SelectField
               label="Theme"
               onChange={setThemeId}
               options={brandThemes.map((theme) => ({
@@ -235,42 +339,20 @@ export function DatavizToolkitPage() {
               }))}
               value={themeId}
             />
-            <Field label="Preset Name" onChange={setPresetName} value={presetName} />
-            <Field label="Headline" onChange={setHeadline} value={headline} />
-            <Field label="Subheadline" onChange={setSubheadline} value={subheadline} />
-            <Field label="Source" onChange={setSource} value={source} />
-          </SurfaceCard>
+            <ToggleField
+              checked={options.showGrid}
+              label="Show Grid"
+              onChange={(checked) => setOptions((current) => ({ ...current, showGrid: checked }))}
+            />
+            <ToggleField
+              checked={options.showLegend}
+              label="Show Legend"
+              onChange={(checked) => setOptions((current) => ({ ...current, showLegend: checked }))}
+            />
+          </CollapsibleSection>
 
-          <SurfaceCard className="p-4">
-            <div className="mb-3 flex items-center justify-between">
-              <div>
-                <p className="text-[11px] uppercase tracking-[0.28em] text-white/42">Preview</p>
-                <h2 className="mt-2 font-display text-2xl text-fog">{chartTemplateDefinitions.find((entry) => entry.id === template)?.label}</h2>
-              </div>
-              <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/54">
-                {dataset.rows.length} rows
-              </span>
-            </div>
-            <div className="overflow-hidden rounded-[28px] border border-white/8 bg-black/30">
-              <div
-                className="aspect-[4/5] w-full [&_svg]:h-full [&_svg]:w-full"
-                dangerouslySetInnerHTML={{ __html: preview.svg }}
-              />
-            </div>
-            {validationMessages.length > 0 ? (
-              <div className="mt-4 space-y-2">
-                {validationMessages.map((message) => (
-                  <p className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/68" key={message}>
-                    {message}
-                  </p>
-                ))}
-              </div>
-            ) : null}
-          </SurfaceCard>
-
-          <SurfaceCard className="space-y-4 p-4">
-            <SectionLabel title="Data" />
-            <Select
+          <CollapsibleSection defaultOpen title="Data & Mapping">
+            <SelectField
               label="Input Mode"
               onChange={(value) => setInputMode(value as 'csv' | 'table' | 'json')}
               options={[
@@ -280,22 +362,17 @@ export function DatavizToolkitPage() {
               ]}
               value={inputMode}
             />
-            <label className="block">
-              <div className="mb-2 text-xs uppercase tracking-[0.18em] text-white/48">Dataset</div>
-              <textarea
-                className="min-h-[220px] w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-3 text-sm text-fog"
-                onChange={(event) => setRawInput(event.target.value)}
-                value={rawInput}
-              />
-            </label>
+            <TextAreaField label="Dataset" onChange={setRawInput} value={rawInput} />
             {error ? <p className="text-sm text-red-200">{error}</p> : null}
-            <Select
+            <SelectField
               label="Category / X Column"
-              onChange={(value) => setMapping((current) => ({ ...current, xColumn: value, labelColumn: value }))}
+              onChange={(value) =>
+                setMapping((current) => ({ ...current, xColumn: value, labelColumn: value }))
+              }
               options={dataset.columns.map((column) => ({ value: column, label: column }))}
               value={resolvedMapping.xColumn ?? ''}
             />
-            <Select
+            <SelectField
               label="Primary Value Column"
               onChange={(value) => setMapping((current) => ({ ...current, yColumn: value }))}
               options={numericColumns.map((column) => ({ value: column, label: column }))}
@@ -306,9 +383,14 @@ export function DatavizToolkitPage() {
               <div className="flex flex-wrap gap-2">
                 {numericColumns.map((column) => {
                   const selected = resolvedMapping.valueColumns.includes(column);
+
                   return (
                     <button
-                      className={`rounded-full border px-3 py-1.5 text-sm ${selected ? 'border-chartreuse/60 bg-chartreuse/15 text-fog' : 'border-white/10 text-white/62'}`}
+                      className={`rounded-full border px-3 py-1.5 text-sm ${
+                        selected
+                          ? 'border-chartreuse/60 bg-chartreuse/15 text-fog'
+                          : 'border-white/10 text-white/62'
+                      }`}
                       key={column}
                       onClick={() =>
                         setMapping((current) => ({
@@ -326,44 +408,150 @@ export function DatavizToolkitPage() {
                 })}
               </div>
             </label>
-            {presets.length > 0 ? (
-              <div className="space-y-2">
-                <SectionLabel title="Saved Presets" />
-                {presets.slice(0, 4).map((preset) => (
-                  <button
-                    className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left"
-                    key={preset.id}
-                    onClick={() => {
-                      setTemplate(preset.template);
-                      setAspectRatio(preset.aspectRatio);
-                      setThemeId(preset.themeId);
-                      setInputMode(preset.inputMode);
-                      setRawInput(preset.rawInput);
-                      setMapping(preset.mapping);
-                      setHeadline(preset.headline);
-                      setSubheadline(preset.subheadline);
-                      setSource(preset.source);
-                      setPresetName(preset.name);
-                    }}
-                    type="button"
+            {templateDefinition?.requiresMultipleSeries && resolvedMapping.valueColumns.length > 0 ? (
+              <SelectField
+                label="Highlight Series"
+                onChange={(value) =>
+                  setOptions((current) => ({ ...current, highlightSeries: value || undefined }))
+                }
+                options={resolvedMapping.valueColumns.map((column) => ({
+                  value: column,
+                  label: column
+                }))}
+                value={options.highlightSeries ?? resolvedMapping.valueColumns[0] ?? ''}
+              />
+            ) : null}
+          </CollapsibleSection>
+
+          <CollapsibleSection defaultOpen={false} title="Palettes">
+            <ToggleField
+              checked={options.useCustomPalette}
+              label="Use Custom Palette"
+              onChange={(checked) =>
+                setOptions((current) => ({
+                  ...current,
+                  useCustomPalette: checked,
+                  customPalette: checked ? buildPaletteSlots(activeTheme, current) : []
+                }))
+              }
+            />
+            {options.useCustomPalette ? (
+              <div className="space-y-4">
+                {editablePalette.map((token, index) => (
+                  <ColorTokenPicker
+                    key={`${index}-${token}`}
+                    label={`Series ${index + 1}`}
+                    onChange={(value) => updateCustomPalette(index, value)}
+                    value={token}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-white/58">
+                The current theme palette stays as the default until you enable custom overrides.
+              </p>
+            )}
+          </CollapsibleSection>
+
+          {presets.length > 0 ? (
+            <CollapsibleSection defaultOpen={false} title="Saved Presets">
+              {presets.slice(0, 4).map((preset) => (
+                <button
+                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left"
+                  key={preset.presetMeta.id}
+                  onClick={() => {
+                    setTemplate(preset.template);
+                    setThemeId(preset.theme);
+                    setOutputPresetId(preset.export.presetId ?? DEFAULT_OUTPUT_PRESET_ID);
+                    setExportFormat(preset.export.format);
+                    setInputMode('csv');
+                    setRawInput(datasetToDelimitedText(preset.data));
+                    setMapping(preset.mapping);
+                    setHeadline(preset.content.headline);
+                    setSubheadline(preset.content.subheadline);
+                    setSource(preset.content.source);
+                    setAnnotationsInput(preset.content.annotations.join('\n'));
+                    setOptions({
+                      ...DEFAULT_OPTIONS,
+                      ...preset.options
+                    });
+                    setPresetName(preset.presetMeta.name);
+                  }}
+                  type="button"
+                >
+                  <p className="text-sm font-semibold text-fog">{preset.presetMeta.name}</p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.18em] text-white/48">
+                    {preset.template} / {preset.export.presetId}
+                  </p>
+                </button>
+              ))}
+            </CollapsibleSection>
+          ) : null}
+        </div>
+      }
+      header={
+        <BrandedHeader
+          actions={
+            <>
+              <button
+                className="rounded-full border border-white/10 px-4 py-2 text-sm text-white/78"
+                onClick={savePreset}
+                type="button"
+              >
+                Save Preset
+              </button>
+              <button
+                className="rounded-full bg-fog px-4 py-2 text-sm font-semibold text-ink"
+                onClick={() => void exportCurrentPreview()}
+                type="button"
+              >
+                Export {exportFormat.toUpperCase()}
+              </button>
+            </>
+          }
+          subtitle="Use dropdown editing panels, fixed chart geometry, and branded output presets to build production-ready editorial graphics."
+          title="Data Visualization Toolkit"
+        />
+      }
+      preview={
+        <PreviewSurface>
+          <SurfaceCard className="flex min-h-0 flex-1 flex-col p-4">
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <p className="text-[11px] uppercase tracking-[0.28em] text-white/42">Preview</p>
+                <h2 className="mt-2 font-display text-2xl text-fog">{templateDefinition?.label}</h2>
+                <p className="mt-2 text-sm text-white/58">
+                  {outputPreset?.label} · {preview.width}×{preview.height}
+                </p>
+              </div>
+              <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/54">
+                {dataset.rows.length} rows
+              </span>
+            </div>
+            <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-[28px] border border-white/8 bg-black/30 p-4">
+              <div
+                className="max-h-full max-w-full overflow-hidden rounded-[24px] [&_svg]:h-full [&_svg]:w-full"
+                dangerouslySetInnerHTML={{ __html: preview.svg }}
+                style={{ aspectRatio: `${preview.width} / ${preview.height}`, width: '100%' }}
+              />
+            </div>
+            {validationMessages.length > 0 ? (
+              <div className="mt-4 space-y-2">
+                {validationMessages.map((message) => (
+                  <p
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/68"
+                    key={message}
                   >
-                    <p className="text-sm font-semibold text-fog">{preset.name}</p>
-                    <p className="mt-1 text-xs uppercase tracking-[0.18em] text-white/48">
-                      {preset.template} / {preset.aspectRatio}
-                    </p>
-                  </button>
+                    {message}
+                  </p>
                 ))}
               </div>
             ) : null}
           </SurfaceCard>
-        </div>
-      </div>
-    </main>
+        </PreviewSurface>
+      }
+    />
   );
-}
-
-function SectionLabel({ title }: { title: string }) {
-  return <p className="text-[11px] uppercase tracking-[0.28em] text-white/42">{title}</p>;
 }
 
 function Field({
@@ -387,31 +575,23 @@ function Field({
   );
 }
 
-function Select({
+function TextAreaField({
   label,
   value,
-  onChange,
-  options
+  onChange
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
-  options: Array<{ value: string; label: string }>;
 }) {
   return (
     <label className="block">
       <div className="mb-2 text-xs uppercase tracking-[0.18em] text-white/48">{label}</div>
-      <select
-        className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-fog"
+      <textarea
+        className="min-h-[120px] w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-3 text-sm text-fog"
         onChange={(event) => onChange(event.target.value)}
         value={value}
-      >
-        {options.map((option) => (
-          <option className="bg-[#111111]" key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+      />
     </label>
   );
 }

--- a/packages/chart-core/src/parser.ts
+++ b/packages/chart-core/src/parser.ts
@@ -59,3 +59,16 @@ export function inferNumericColumns(dataset: DatavizDataset) {
     })
   );
 }
+
+export function datasetToDelimitedText(dataset: DatavizDataset) {
+  if (dataset.columns.length === 0) {
+    return '';
+  }
+
+  const header = dataset.columns.join(',');
+  const rows = dataset.rows.map((row) =>
+    dataset.columns.map((column) => row[column] ?? '').join(',')
+  );
+
+  return [header, ...rows].join('\n');
+}

--- a/packages/chart-core/src/renderSvg.ts
+++ b/packages/chart-core/src/renderSvg.ts
@@ -1,10 +1,28 @@
 import { brandThemes, resolveColor } from '@packages/design-tokens/src/colors';
-import type { DatavizDataset, DatavizFieldMapping, DatavizTemplate, SuiteAspectRatio } from '@packages/config-schema/src/document';
+import type {
+  DatavizDataset,
+  DatavizFieldMapping,
+  DatavizOptions,
+  DatavizTemplate,
+  SuiteAspectRatio
+} from '@packages/config-schema/src/document';
 
 const aspectSizes: Record<SuiteAspectRatio, { width: number; height: number }> = {
   '1:1': { width: 1080, height: 1080 },
   '4:5': { width: 1080, height: 1350 },
   '16:9': { width: 1600, height: 900 }
+};
+
+type TextBlock = {
+  fontSize: number;
+  lineHeight: number;
+  lines: string[];
+  height: number;
+};
+
+type LegendLayout = {
+  items: Array<{ label: string; x: number; y: number; color: string }>;
+  height: number;
 };
 
 function escapeMarkup(value: string) {
@@ -17,6 +35,121 @@ function escapeMarkup(value: string) {
 
 function getTheme(themeId: string) {
   return brandThemes.find((theme) => theme.id === themeId) ?? brandThemes[0];
+}
+
+function estimateTextWidth(text: string, fontSize: number, widthFactor = 0.56) {
+  return text.length * fontSize * widthFactor;
+}
+
+function wrapText(text: string, maxWidth: number, fontSize: number) {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+
+  if (words.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (!current || estimateTextWidth(candidate, fontSize) <= maxWidth) {
+      current = candidate;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+function fitTextBlock({
+  text,
+  maxWidth,
+  initialFontSize,
+  minFontSize,
+  lineHeight,
+  maxHeight
+}: {
+  text: string;
+  maxWidth: number;
+  initialFontSize: number;
+  minFontSize: number;
+  lineHeight: number;
+  maxHeight: number;
+}) {
+  if (!text.trim()) {
+    return {
+      fontSize: initialFontSize,
+      lineHeight,
+      lines: [],
+      height: 0
+    } satisfies TextBlock;
+  }
+
+  for (let fontSize = initialFontSize; fontSize >= minFontSize; fontSize -= 2) {
+    const lines = wrapText(text, maxWidth, fontSize);
+    const height = lines.length * fontSize * lineHeight;
+
+    if (height <= maxHeight) {
+      return {
+        fontSize,
+        lineHeight,
+        lines,
+        height
+      } satisfies TextBlock;
+    }
+  }
+
+  const lines = wrapText(text, maxWidth, minFontSize);
+
+  return {
+    fontSize: minFontSize,
+    lineHeight,
+    lines,
+    height: lines.length * minFontSize * lineHeight
+  } satisfies TextBlock;
+}
+
+function renderTextBlock({
+  x,
+  y,
+  block,
+  fill,
+  opacity = 1,
+  family,
+  weight = 400,
+  anchor = 'start',
+  dataSlot
+}: {
+  x: number;
+  y: number;
+  block: TextBlock;
+  fill: string;
+  opacity?: number;
+  family: string;
+  weight?: number;
+  anchor?: 'start' | 'middle' | 'end';
+  dataSlot?: string;
+}) {
+  if (block.lines.length === 0) {
+    return '';
+  }
+
+  const attributes = dataSlot ? ` data-slot="${dataSlot}"` : '';
+
+  return `
+    <text${attributes} x="${x}" y="${y}" fill="${fill}" opacity="${opacity}" font-size="${block.fontSize}" font-family="${family}" font-weight="${weight}" text-anchor="${anchor}">
+      ${block.lines
+        .map((line, index) => `<tspan x="${x}" y="${y + index * block.fontSize * block.lineHeight}">${escapeMarkup(line)}</tspan>`)
+        .join('')}
+    </text>
+  `;
 }
 
 function getNumbers(dataset: DatavizDataset, mapping: DatavizFieldMapping) {
@@ -63,8 +196,7 @@ function pieSlices(values: Array<{ label: string; value: number }>, cx: number, 
     const y1 = cy + Math.sin(angle) * radius;
     const x2 = cx + Math.cos(nextAngle) * radius;
     const y2 = cy + Math.sin(nextAngle) * radius;
-    const outer = `M ${cx} ${cy} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`;
-    let path = outer;
+    let path = `M ${cx} ${cy} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`;
 
     if (innerRadius > 0) {
       const ix1 = cx + Math.cos(nextAngle) * innerRadius;
@@ -79,6 +211,181 @@ function pieSlices(values: Array<{ label: string; value: number }>, cx: number, 
   });
 }
 
+function getLegendLabels(
+  dataset: DatavizDataset,
+  mapping: DatavizFieldMapping,
+  template: DatavizTemplate
+) {
+  if (template === 'pie-donut') {
+    return buildBarSeries(dataset, mapping).map((item) => item.label);
+  }
+
+  if (template === 'stacked-bar' || template === 'multi-line' || template === 'focused-line') {
+    return mapping.valueColumns.length > 0 ? mapping.valueColumns : dataset.columns.slice(1, 4);
+  }
+
+  if (template === 'line' || template === 'bar' || template === 'big-number' || template === 'categorical-ranking') {
+    return [mapping.yColumn ?? mapping.valueColumns[0] ?? 'Value'].filter(Boolean);
+  }
+
+  if (template === 'scatter') {
+    return [mapping.yColumn ?? 'Value'].filter(Boolean);
+  }
+
+  return [mapping.yColumn ?? mapping.valueColumns[0] ?? 'Value'].filter(Boolean);
+}
+
+function layoutLegend(
+  labels: string[],
+  colors: string[],
+  maxWidth: number,
+  startX: number,
+  startY: number
+): LegendLayout {
+  let cursorX = startX;
+  let cursorY = startY;
+  const rowHeight = 28;
+  const itemGap = 20;
+  const items: LegendLayout['items'] = [];
+
+  for (const [index, label] of labels.entries()) {
+    const itemWidth = 26 + estimateTextWidth(label, 18, 0.54);
+
+    if (cursorX !== startX && cursorX + itemWidth > startX + maxWidth) {
+      cursorX = startX;
+      cursorY += rowHeight;
+    }
+
+    items.push({
+      label,
+      x: cursorX,
+      y: cursorY,
+      color: colors[index % colors.length]
+    });
+
+    cursorX += itemWidth + itemGap;
+  }
+
+  return {
+    items,
+    height: items.length > 0 ? cursorY - startY + rowHeight : 0
+  };
+}
+
+function niceStep(maxValue: number, tickCount = 4) {
+  const roughStep = Math.max(maxValue, 1) / tickCount;
+  const magnitude = 10 ** Math.floor(Math.log10(roughStep));
+  const residual = roughStep / magnitude;
+
+  if (residual >= 5) {
+    return 5 * magnitude;
+  }
+
+  if (residual >= 2) {
+    return 2 * magnitude;
+  }
+
+  return magnitude;
+}
+
+function getNumericTicks(maxValue: number, tickCount = 4) {
+  const step = niceStep(maxValue, tickCount);
+  const end = Math.ceil(Math.max(maxValue, step) / step) * step;
+  const ticks: number[] = [];
+
+  for (let value = 0; value <= end + step / 2; value += step) {
+    ticks.push(Number(value.toFixed(2)));
+  }
+
+  return ticks;
+}
+
+function formatTick(value: number) {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
+}
+
+function renderCartesianAxes({
+  chartX,
+  chartY,
+  chartWidth,
+  chartHeight,
+  xTickLabels,
+  xTickPositions,
+  yMaxValue,
+  baseText,
+  showGrid
+}: {
+  chartX: number;
+  chartY: number;
+  chartWidth: number;
+  chartHeight: number;
+  xTickLabels: string[];
+  xTickPositions: number[];
+  yMaxValue: number;
+  baseText: string;
+  showGrid: boolean;
+}) {
+  const yTicks = getNumericTicks(yMaxValue);
+  const yAxisMarkup = yTicks
+    .map((value) => {
+      const y = chartY + chartHeight - (value / yTicks[yTicks.length - 1]) * chartHeight;
+      return `
+        ${showGrid ? `<line data-axis-grid="y" x1="${chartX}" y1="${y}" x2="${chartX + chartWidth}" y2="${y}" stroke="${baseText}" opacity="0.1" />` : ''}
+        <line data-axis="y-tick" x1="${chartX - 8}" y1="${y}" x2="${chartX}" y2="${y}" stroke="${baseText}" opacity="0.5" />
+        <text data-axis-label="y" x="${chartX - 16}" y="${y + 5}" fill="${baseText}" opacity="0.62" font-size="18" text-anchor="end" font-family="Avenir Next, Segoe UI, sans-serif">${formatTick(value)}</text>
+      `;
+    })
+    .join('');
+
+  const xAxisMarkup = xTickLabels
+    .map((label, index) => {
+      const x = xTickPositions[index];
+      return `
+        <line data-axis="x-tick" x1="${x}" y1="${chartY + chartHeight}" x2="${x}" y2="${chartY + chartHeight + 8}" stroke="${baseText}" opacity="0.5" />
+        <text data-axis-label="x" x="${x}" y="${chartY + chartHeight + 30}" fill="${baseText}" opacity="0.72" font-size="18" text-anchor="middle" font-family="Avenir Next, Segoe UI, sans-serif">${escapeMarkup(label)}</text>
+      `;
+    })
+    .join('');
+
+  return `
+    <g data-axis-group="cartesian">
+      <line data-axis="y" x1="${chartX}" y1="${chartY}" x2="${chartX}" y2="${chartY + chartHeight}" stroke="${baseText}" opacity="0.34" />
+      <line data-axis="x" x1="${chartX}" y1="${chartY + chartHeight}" x2="${chartX + chartWidth}" y2="${chartY + chartHeight}" stroke="${baseText}" opacity="0.34" />
+      ${yAxisMarkup}
+      ${xAxisMarkup}
+    </g>
+  `;
+}
+
+function renderNumericXAxis({
+  chartX,
+  chartY,
+  chartWidth,
+  chartHeight,
+  maxValue,
+  baseText
+}: {
+  chartX: number;
+  chartY: number;
+  chartWidth: number;
+  chartHeight: number;
+  maxValue: number;
+  baseText: string;
+}) {
+  const ticks = getNumericTicks(maxValue);
+  const maxTick = ticks[ticks.length - 1] || 1;
+
+  return ticks
+    .map((value) => {
+      const x = chartX + (value / maxTick) * chartWidth;
+      return `
+        <line data-axis="x-tick" x1="${x}" y1="${chartY + chartHeight}" x2="${x}" y2="${chartY + chartHeight + 8}" stroke="${baseText}" opacity="0.5" />
+        <text data-axis-label="x" x="${x}" y="${chartY + chartHeight + 30}" fill="${baseText}" opacity="0.72" font-size="18" text-anchor="middle" font-family="Avenir Next, Segoe UI, sans-serif">${formatTick(value)}</text>
+      `;
+    })
+    .join('');
+}
+
 export function renderChartSvg({
   dataset,
   mapping,
@@ -87,7 +394,10 @@ export function renderChartSvg({
   headline,
   subheadline,
   source,
-  themeId
+  themeId,
+  annotations = [],
+  options,
+  size
 }: {
   dataset: DatavizDataset;
   mapping: DatavizFieldMapping;
@@ -97,110 +407,352 @@ export function renderChartSvg({
   subheadline: string;
   source: string;
   themeId: string;
+  annotations?: string[];
+  options?: Partial<DatavizOptions>;
+  size?: { width: number; height: number };
 }) {
   const theme = getTheme(themeId);
-  const { width, height } = aspectSizes[aspectRatio];
-  const pad = 80;
-  const chartX = pad;
-  const chartY = 250;
-  const chartWidth = width - pad * 2;
-  const chartHeight = height - 380;
-  const palette = theme.chartPalette.map((token) => resolveColor(token));
+  const { width, height } = size ?? aspectSizes[aspectRatio];
+  const resolvedOptions: DatavizOptions = {
+    showGrid: true,
+    showLegend: true,
+    animate: false,
+    highlightSeries: undefined,
+    useCustomPalette: false,
+    customPalette: [],
+    ...options
+  };
+  const paletteSource =
+    resolvedOptions.useCustomPalette && resolvedOptions.customPalette.length > 0
+      ? resolvedOptions.customPalette
+      : theme.chartPalette;
+  const palette = paletteSource.map((token) => resolveColor(token));
   const baseText = resolveColor(theme.canvas.foreground);
   const accent = resolveColor(theme.canvas.accent);
   const background = resolveColor(theme.canvas.background);
+  const pad = 80;
+  const annotationColumnWidth = annotations.length > 0 ? Math.min(240, width * 0.24) : 0;
+
+  let headlineSize = 48;
+  let subheadlineSize = 24;
+  let headlineBlock: TextBlock = fitTextBlock({
+    text: headline || 'Untitled chart',
+    maxWidth: width - pad * 2,
+    initialFontSize: headlineSize,
+    minFontSize: 36,
+    lineHeight: 1.06,
+    maxHeight: 120
+  });
+  let subheadlineBlock: TextBlock = fitTextBlock({
+    text: subheadline,
+    maxWidth: width - pad * 2,
+    initialFontSize: subheadlineSize,
+    minFontSize: 18,
+    lineHeight: 1.26,
+    maxHeight: 92
+  });
+  const annotationBlocks = annotations.slice(0, 3).map((annotation) =>
+    fitTextBlock({
+      text: annotation,
+      maxWidth: annotationColumnWidth,
+      initialFontSize: 16,
+      minFontSize: 14,
+      lineHeight: 1.2,
+      maxHeight: 42
+    })
+  );
+  const legendLabels = getLegendLabels(dataset, mapping, template);
+  let legendLayout: LegendLayout = { items: [], height: 0 };
+  let chartY = 0;
+
+  for (let iteration = 0; iteration < 8; iteration += 1) {
+    const headlineWidth = width - pad * 2 - (annotationColumnWidth > 0 ? annotationColumnWidth + 24 : 0);
+
+    headlineBlock = fitTextBlock({
+      text: headline || 'Untitled chart',
+      maxWidth: headlineWidth,
+      initialFontSize: headlineSize,
+      minFontSize: 36,
+      lineHeight: 1.06,
+      maxHeight: 120
+    });
+    subheadlineBlock = fitTextBlock({
+      text: subheadline,
+      maxWidth: width - pad * 2,
+      initialFontSize: subheadlineSize,
+      minFontSize: 18,
+      lineHeight: 1.26,
+      maxHeight: 96
+    });
+
+    const headlineBottom = 170 + headlineBlock.height;
+    const subheadlineTop = headlineBottom + (subheadlineBlock.lines.length > 0 ? 18 : 0);
+    const subheadlineBottom = subheadlineTop + subheadlineBlock.height;
+    const legendTop = subheadlineBottom + (legendLabels.length > 0 ? 22 : 0);
+
+    legendLayout = resolvedOptions.showLegend
+      ? layoutLegend(legendLabels, palette, width - pad * 2, pad, legendTop)
+      : { items: [], height: 0 };
+    chartY = legendTop + legendLayout.height + 28;
+
+    if (chartY <= height * 0.42 || (headlineSize <= 36 && subheadlineSize <= 18)) {
+      break;
+    }
+
+    if (subheadlineSize > 18) {
+      subheadlineSize -= 2;
+    } else if (headlineSize > 36) {
+      headlineSize -= 2;
+    }
+  }
+
+  const chartX = pad;
+  const chartWidth = width - pad * 2;
+  const chartHeight = Math.max(220, height - chartY - 120);
+  const headerClipHeight = chartY - 22;
+  const annotationMarkup = annotationBlocks
+    .map((block, index) =>
+      renderTextBlock({
+        x: width - pad - annotationColumnWidth,
+        y: 118 + index * 34,
+        block,
+        fill: baseText,
+        opacity: 0.68,
+        family: 'Avenir Next, Segoe UI, sans-serif',
+        weight: 500,
+        dataSlot: 'annotation'
+      })
+    )
+    .join('');
+  const headerMarkup = `
+    <g data-slot="header" clip-path="url(#header-clip)">
+      <text x="${pad}" y="110" fill="${baseText}" opacity="0.62" font-size="18" font-family="Avenir Next, Segoe UI, sans-serif">Data Visualization Toolkit</text>
+      ${annotationMarkup}
+      ${renderTextBlock({
+        x: pad,
+        y: 170,
+        block: headlineBlock,
+        fill: baseText,
+        family: 'Iowan Old Style, Times New Roman, serif',
+        weight: 700,
+        dataSlot: 'headline'
+      })}
+      ${renderTextBlock({
+        x: pad,
+        y: 170 + headlineBlock.height + (subheadlineBlock.lines.length > 0 ? 18 : 0),
+        block: subheadlineBlock,
+        fill: baseText,
+        opacity: 0.72,
+        family: 'Avenir Next, Segoe UI, sans-serif',
+        weight: 500,
+        dataSlot: 'subheadline'
+      })}
+    </g>
+  `;
+  const legendMarkup =
+    resolvedOptions.showLegend && legendLayout.items.length > 0
+      ? `
+        <g data-slot="legend">
+          ${legendLayout.items
+            .map(
+              (item) => `
+                <circle cx="${item.x + 8}" cy="${item.y}" r="8" fill="${item.color}" />
+                <text x="${item.x + 24}" y="${item.y + 6}" fill="${baseText}" opacity="0.72" font-size="18" font-family="Avenir Next, Segoe UI, sans-serif">${escapeMarkup(item.label)}</text>
+              `
+            )
+            .join('')}
+        </g>
+      `
+      : '';
 
   let chartMarkup = '';
+  let axisMarkup = '';
 
   if (template === 'big-number') {
     const firstValue = getNumbers(dataset, mapping)[0] ?? 0;
+    const valueLabel = mapping.yColumn ?? mapping.valueColumns[0] ?? 'Value';
+    const bigNumber = firstValue.toLocaleString();
+    const estimatedWidth = Math.max(estimateTextWidth(bigNumber, 260, 0.62), 1);
+    const scaledFontSize = Math.min(260, (chartWidth * 0.72 * 260) / estimatedWidth, chartHeight * 0.42);
+    const bigNumberSize = Math.max(180, Math.round(scaledFontSize));
+    const centerX = chartX + chartWidth / 2;
+    const valueY = chartY + chartHeight * 0.54;
+
     chartMarkup = `
-      <text x="${pad}" y="${chartY + 120}" fill="${accent}" font-size="180" font-family="Avenir Next, Segoe UI, sans-serif" font-weight="700">${firstValue.toLocaleString()}</text>
-      <text x="${pad}" y="${chartY + 200}" fill="${baseText}" opacity="0.72" font-size="28" font-family="Avenir Next, Segoe UI, sans-serif">${escapeMarkup(mapping.yColumn ?? mapping.valueColumns[0] ?? 'Value')}</text>
+      <g data-template="big-number">
+        <text data-role="big-number-value" x="${centerX}" y="${valueY}" fill="${accent}" font-size="${bigNumberSize}" font-family="Avenir Next, Segoe UI, sans-serif" font-weight="700" text-anchor="middle">${bigNumber}</text>
+        <text x="${centerX}" y="${valueY + bigNumberSize * 0.3}" fill="${baseText}" opacity="0.72" font-size="30" font-family="Avenir Next, Segoe UI, sans-serif" text-anchor="middle">${escapeMarkup(valueLabel)}</text>
+      </g>
     `;
   } else if (template === 'line' || template === 'multi-line' || template === 'focused-line') {
-    const valueColumns = template === 'line'
-      ? [mapping.yColumn ?? mapping.valueColumns[0] ?? dataset.columns[1] ?? '']
-      : (mapping.valueColumns.length > 0 ? mapping.valueColumns : dataset.columns.slice(1, 4));
-    chartMarkup += `<line x1="${chartX}" y1="${chartY + chartHeight}" x2="${chartX + chartWidth}" y2="${chartY + chartHeight}" stroke="${baseText}" opacity="0.18" />`;
-    chartMarkup += `<line x1="${chartX}" y1="${chartY}" x2="${chartX}" y2="${chartY + chartHeight}" stroke="${baseText}" opacity="0.18" />`;
+    const valueColumns =
+      template === 'line'
+        ? [mapping.yColumn ?? mapping.valueColumns[0] ?? dataset.columns[1] ?? '']
+        : mapping.valueColumns.length > 0
+          ? mapping.valueColumns
+          : dataset.columns.slice(1, 4);
+    const highlightSeries = resolvedOptions.highlightSeries ?? valueColumns[0];
+    const xLabels = dataset.rows.map(
+      (row) => row[mapping.xColumn ?? mapping.labelColumn ?? dataset.columns[0] ?? ''] ?? ''
+    );
+    const xPositions = xLabels.map((_, index) =>
+      chartX + (chartWidth / Math.max(1, xLabels.length - 1)) * index
+    );
+    const allValues = valueColumns.flatMap((column) =>
+      dataset.rows.map((row) => Number(row[column] ?? 0))
+    );
+    const maxValue = Math.max(1, ...allValues);
+
+    axisMarkup = renderCartesianAxes({
+      chartX,
+      chartY,
+      chartWidth,
+      chartHeight,
+      xTickLabels: xLabels,
+      xTickPositions: xPositions,
+      yMaxValue: maxValue,
+      baseText,
+      showGrid: resolvedOptions.showGrid
+    });
+
+    chartMarkup += `<g data-template="line-family">`;
     valueColumns.forEach((column, index) => {
       const values = dataset.rows.map((row) => Number(row[column] ?? 0));
-      const highlight = template !== 'focused-line' || index === 0;
+      const highlight = template !== 'focused-line' || column === highlightSeries;
       chartMarkup += `
-        <path d="${linePoints(values, chartX, chartY, chartWidth, chartHeight)}" fill="none" stroke="${palette[index % palette.length]}" stroke-width="${highlight ? 5 : 3}" opacity="${highlight ? 1 : 0.34}" />
+        <path data-role="plot-line" d="${linePoints(values, chartX, chartY, chartWidth, chartHeight)}" fill="none" stroke="${palette[index % palette.length]}" stroke-width="${highlight ? 5 : 3}" opacity="${highlight ? 1 : 0.34}" />
       `;
     });
+    chartMarkup += `</g>`;
   } else if (template === 'scatter') {
     const xValues = dataset.rows.map((row) => Number(row[mapping.xColumn ?? dataset.columns[0] ?? ''] ?? 0));
     const yValues = dataset.rows.map((row) => Number(row[mapping.yColumn ?? dataset.columns[1] ?? ''] ?? 0));
     const maxX = Math.max(1, ...xValues);
     const maxY = Math.max(1, ...yValues);
-    chartMarkup += `<rect x="${chartX}" y="${chartY}" width="${chartWidth}" height="${chartHeight}" fill="none" stroke="${baseText}" opacity="0.12" />`;
+    const xTicks = getNumericTicks(maxX);
+    const xPositions = xTicks.map((value) => chartX + (value / xTicks[xTicks.length - 1]) * chartWidth);
+
+    axisMarkup = renderCartesianAxes({
+      chartX,
+      chartY,
+      chartWidth,
+      chartHeight,
+      xTickLabels: xTicks.map(formatTick),
+      xTickPositions: xPositions,
+      yMaxValue: maxY,
+      baseText,
+      showGrid: resolvedOptions.showGrid
+    });
+
     chartMarkup += dataset.rows
       .map((row, index) => {
         const x = chartX + (xValues[index] / maxX) * chartWidth;
         const y = chartY + chartHeight - (yValues[index] / maxY) * chartHeight;
-        return `<circle cx="${x}" cy="${y}" r="10" fill="${palette[index % palette.length]}" opacity="0.88" />`;
+        return `<circle data-role="plot-point" cx="${x}" cy="${y}" r="10" fill="${palette[index % palette.length]}" opacity="0.88" />`;
       })
       .join('');
   } else if (template === 'pie-donut') {
     const series = buildBarSeries(dataset, mapping);
-    const paths = pieSlices(series, width / 2, chartY + chartHeight / 2, Math.min(chartWidth, chartHeight) / 2.3, 120);
-    chartMarkup += paths
-      .map((path, index) => `<path d="${path}" fill="${palette[index % palette.length]}" opacity="0.94" />`)
+    const paths = pieSlices(
+      series,
+      chartX + chartWidth / 2,
+      chartY + chartHeight / 2,
+      Math.min(chartWidth, chartHeight) / 2.3,
+      120
+    );
+    chartMarkup = paths
+      .map((path, index) => `<path data-role="plot-slice" d="${path}" fill="${palette[index % palette.length]}" opacity="0.94" />`)
       .join('');
   } else if (template === 'stacked-bar') {
     const rows = buildStackedSeries(dataset, mapping);
     const maxTotal = Math.max(1, ...rows.map((row) => row.values.reduce((sum, item) => sum + item.value, 0)));
-    const barWidth = chartWidth / Math.max(1, rows.length) - 24;
+    const slotWidth = chartWidth / Math.max(1, rows.length);
+    const barWidth = Math.max(24, slotWidth - 28);
+    const xLabels = rows.map((row) => row.label);
+    const xPositions = rows.map((_, index) => chartX + index * slotWidth + slotWidth / 2);
+
+    axisMarkup = renderCartesianAxes({
+      chartX,
+      chartY,
+      chartWidth,
+      chartHeight,
+      xTickLabels: xLabels,
+      xTickPositions: xPositions,
+      yMaxValue: maxTotal,
+      baseText,
+      showGrid: resolvedOptions.showGrid
+    });
+
     chartMarkup += rows
       .map((row, index) => {
         let cursorY = chartY + chartHeight;
-        const x = chartX + index * (barWidth + 24);
-        const stacks = row.values
+        const x = chartX + index * slotWidth + (slotWidth - barWidth) / 2;
+        return row.values
           .map((item, stackIndex) => {
             const segmentHeight = (item.value / maxTotal) * chartHeight;
             cursorY -= segmentHeight;
-            return `<rect x="${x}" y="${cursorY}" width="${barWidth}" height="${segmentHeight}" rx="10" fill="${palette[stackIndex % palette.length]}" />`;
+            return `<rect data-role="plot-bar" x="${x}" y="${cursorY}" width="${barWidth}" height="${segmentHeight}" rx="10" fill="${palette[stackIndex % palette.length]}" />`;
           })
           .join('');
-        return `${stacks}<text x="${x + barWidth / 2}" y="${chartY + chartHeight + 34}" fill="${baseText}" opacity="0.7" text-anchor="middle" font-size="20">${escapeMarkup(row.label)}</text>`;
+      })
+      .join('');
+  } else if (template === 'categorical-ranking') {
+    const series = buildBarSeries(dataset, mapping).sort((a, b) => b.value - a.value).slice(0, 6);
+    const maxValue = Math.max(1, ...series.map((item) => item.value));
+
+    axisMarkup = `
+      <g data-axis-group="ranking">
+        <line data-axis="x" x1="${chartX}" y1="${chartY + chartHeight}" x2="${chartX + chartWidth}" y2="${chartY + chartHeight}" stroke="${baseText}" opacity="0.34" />
+        ${renderNumericXAxis({
+          chartX,
+          chartY,
+          chartWidth,
+          chartHeight,
+          maxValue,
+          baseText
+        })}
+      </g>
+    `;
+
+    chartMarkup += series
+      .map((item, index) => {
+        const y = chartY + index * 66;
+        const widthValue = (item.value / maxValue) * chartWidth;
+        return `
+          <text x="${chartX}" y="${y - 12}" fill="${baseText}" font-size="22">${escapeMarkup(item.label)}</text>
+          <rect data-role="plot-bar" x="${chartX}" y="${y}" width="${widthValue}" height="24" rx="12" fill="${palette[index % palette.length]}" />
+          <text x="${chartX + widthValue + 14}" y="${y + 19}" fill="${baseText}" font-size="20">${item.value.toLocaleString()}</text>
+        `;
       })
       .join('');
   } else {
-    const series = buildBarSeries(dataset, mapping).sort((a, b) =>
-      template === 'categorical-ranking' ? b.value - a.value : 0
-    );
+    const series = buildBarSeries(dataset, mapping);
     const maxValue = Math.max(1, ...series.map((item) => item.value));
+    const slotWidth = chartWidth / Math.max(1, series.length);
+    const barWidth = Math.max(28, slotWidth - 28);
+    const xLabels = series.map((item) => item.label);
+    const xPositions = series.map((_, index) => chartX + index * slotWidth + slotWidth / 2);
 
-    if (template === 'categorical-ranking') {
-      chartMarkup += series
-        .slice(0, 6)
-        .map((item, index) => {
-          const y = chartY + index * 66;
-          const widthValue = (item.value / maxValue) * chartWidth;
-          return `
-            <text x="${chartX}" y="${y - 12}" fill="${baseText}" font-size="22">${escapeMarkup(item.label)}</text>
-            <rect x="${chartX}" y="${y}" width="${widthValue}" height="24" rx="12" fill="${palette[index % palette.length]}" />
-            <text x="${chartX + widthValue + 14}" y="${y + 19}" fill="${baseText}" font-size="20">${item.value.toLocaleString()}</text>
-          `;
-        })
-        .join('');
-    } else {
-      const barWidth = chartWidth / Math.max(1, series.length) - 24;
-      chartMarkup += series
-        .map((item, index) => {
-          const heightValue = (item.value / maxValue) * chartHeight;
-          const x = chartX + index * (barWidth + 24);
-          const y = chartY + chartHeight - heightValue;
-          return `
-            <rect x="${x}" y="${y}" width="${barWidth}" height="${heightValue}" rx="18" fill="${palette[index % palette.length]}" />
-            <text x="${x + barWidth / 2}" y="${chartY + chartHeight + 34}" fill="${baseText}" opacity="0.7" text-anchor="middle" font-size="20">${escapeMarkup(item.label)}</text>
-          `;
-        })
-        .join('');
-    }
+    axisMarkup = renderCartesianAxes({
+      chartX,
+      chartY,
+      chartWidth,
+      chartHeight,
+      xTickLabels: xLabels,
+      xTickPositions: xPositions,
+      yMaxValue: maxValue,
+      baseText,
+      showGrid: resolvedOptions.showGrid
+    });
+
+    chartMarkup += series
+      .map((item, index) => {
+        const heightValue = (item.value / maxValue) * chartHeight;
+        const x = chartX + index * slotWidth + (slotWidth - barWidth) / 2;
+        const y = chartY + chartHeight - heightValue;
+        return `<rect data-role="plot-bar" x="${x}" y="${y}" width="${barWidth}" height="${heightValue}" rx="18" fill="${palette[index % palette.length]}" />`;
+      })
+      .join('');
   }
 
   return {
@@ -208,12 +760,17 @@ export function renderChartSvg({
     height,
     svg: `
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">
+        <defs>
+          <clipPath id="header-clip">
+            <rect x="${pad}" y="72" width="${width - pad * 2}" height="${headerClipHeight}" rx="0" />
+          </clipPath>
+        </defs>
         <rect width="${width}" height="${height}" fill="${background}" />
         <rect x="32" y="32" width="${width - 64}" height="${height - 64}" rx="36" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)" />
-        <text x="${pad}" y="110" fill="${baseText}" opacity="0.62" font-size="18" font-family="Avenir Next, Segoe UI, sans-serif">Data Visualization Toolkit</text>
-        <text x="${pad}" y="170" fill="${baseText}" font-size="48" font-family="Iowan Old Style, Times New Roman, serif" font-weight="700">${escapeMarkup(headline || 'Untitled chart')}</text>
-        <text x="${pad}" y="212" fill="${baseText}" opacity="0.72" font-size="24" font-family="Avenir Next, Segoe UI, sans-serif">${escapeMarkup(subheadline)}</text>
-        ${chartMarkup}
+        ${headerMarkup}
+        ${legendMarkup}
+        ${axisMarkup}
+        <g data-slot="chart">${chartMarkup}</g>
         <text x="${pad}" y="${height - 80}" fill="${baseText}" opacity="0.58" font-size="18" font-family="Avenir Next, Segoe UI, sans-serif">${escapeMarkup(source)}</text>
       </svg>
     `.trim()

--- a/packages/chart-core/src/templates.ts
+++ b/packages/chart-core/src/templates.ts
@@ -11,3 +11,7 @@ export const chartTemplateDefinitions: ChartTemplateDefinition[] = [
   { id: 'scatter', label: 'Scatter', summary: 'Two-value relationship' },
   { id: 'pie-donut', label: 'Pie / Donut', summary: 'Composition snapshot' }
 ];
+
+export function getChartTemplateDefinition(id: ChartTemplateDefinition['id']) {
+  return chartTemplateDefinitions.find((entry) => entry.id === id);
+}

--- a/packages/chart-core/src/validation.ts
+++ b/packages/chart-core/src/validation.ts
@@ -1,0 +1,67 @@
+import type {
+  DatavizDataset,
+  DatavizFieldMapping,
+  DatavizTemplate
+} from '@packages/config-schema/src/document';
+import { inferNumericColumns } from './parser';
+import { getChartTemplateDefinition } from './templates';
+
+function hasNumericSelection(mapping: DatavizFieldMapping) {
+  return Boolean(mapping.yColumn) || mapping.valueColumns.length > 0;
+}
+
+function isNumericColumn(dataset: DatavizDataset, column?: string) {
+  if (!column) {
+    return false;
+  }
+
+  return inferNumericColumns(dataset).includes(column);
+}
+
+export function getDatavizValidationMessages({
+  dataset,
+  mapping,
+  template,
+  highlightSeries
+}: {
+  dataset: DatavizDataset;
+  mapping: DatavizFieldMapping;
+  template: DatavizTemplate;
+  highlightSeries?: string;
+}) {
+  const messages: string[] = [];
+  const templateDefinition = getChartTemplateDefinition(template);
+
+  if (dataset.rows.length === 0) {
+    messages.push('Add data to unlock a valid chart preview.');
+    return messages;
+  }
+
+  if (template !== 'big-number' && !mapping.xColumn) {
+    messages.push('Choose a category or x-axis column.');
+  }
+
+  if (templateDefinition?.requiresMultipleSeries && mapping.valueColumns.length < 2) {
+    messages.push('Choose at least two numeric series columns for this template.');
+  }
+
+  if (!hasNumericSelection(mapping)) {
+    messages.push('Choose at least one numeric value column.');
+  }
+
+  if (template === 'scatter') {
+    if (!isNumericColumn(dataset, mapping.xColumn)) {
+      messages.push('Scatter charts require a numeric X column.');
+    }
+
+    if (!isNumericColumn(dataset, mapping.yColumn)) {
+      messages.push('Scatter charts require a numeric Y column.');
+    }
+  }
+
+  if (template === 'focused-line' && highlightSeries && !mapping.valueColumns.includes(highlightSeries)) {
+    messages.push('Focused line highlight must match one of the selected series columns.');
+  }
+
+  return Array.from(new Set(messages));
+}

--- a/packages/config-schema/src/document.ts
+++ b/packages/config-schema/src/document.ts
@@ -217,7 +217,9 @@ export const datavizOptionsSchema = z.object({
   showGrid: z.boolean().default(true),
   showLegend: z.boolean().default(true),
   animate: z.boolean().default(false),
-  highlightSeries: z.string().optional()
+  highlightSeries: z.string().optional(),
+  useCustomPalette: z.boolean().default(false),
+  customPalette: z.array(z.string()).default([])
 });
 
 export const datavizToolkitDocumentSchema = z.object({
@@ -227,7 +229,8 @@ export const datavizToolkitDocumentSchema = z.object({
   aspectRatio: z.enum(suiteAspectRatios),
   export: z.object({
     format: z.enum(['png', 'svg']),
-    filename: z.string()
+    filename: z.string(),
+    presetId: z.string().default('portrait-4x5')
   }),
   presetMeta: presetMetaSchema,
   content: datavizContentSchema,

--- a/packages/studio-shell/src/outputPresets.ts
+++ b/packages/studio-shell/src/outputPresets.ts
@@ -28,6 +28,14 @@ const outputPresets = [
     class: 'image'
   },
   {
+    id: 'landscape-16x9',
+    label: 'Landscape',
+    width: 1920,
+    height: 1080,
+    aspectRatio: '16:9',
+    class: 'image'
+  },
+  {
     id: 'stories-9x16',
     label: 'Stories / Reels / TikTok',
     width: 1080,

--- a/packages/ui/src/CollapsibleSection.tsx
+++ b/packages/ui/src/CollapsibleSection.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useId, useState, type ReactNode } from 'react';
+import { SurfaceCard } from './SurfaceCard';
+
+export function CollapsibleSection({
+  title,
+  children,
+  defaultOpen = true,
+  actions
+}: {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  actions?: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = useId();
+
+  return (
+    <SurfaceCard className="overflow-hidden">
+      <div className="flex items-center justify-between gap-3 border-b border-white/8 px-4 py-3">
+        <button
+          aria-controls={panelId}
+          aria-expanded={open}
+          className="flex flex-1 items-center justify-between gap-3 text-left"
+          onClick={() => setOpen((current) => !current)}
+          type="button"
+        >
+          <span className="text-[11px] uppercase tracking-[0.28em] text-white/42">{title}</span>
+          <span
+            aria-hidden="true"
+            className={`text-sm text-white/58 transition-transform ${open ? 'rotate-180' : ''}`}
+          >
+            ⌄
+          </span>
+        </button>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </div>
+      {open ? (
+        <div className="space-y-4 p-4" id={panelId}>
+          {children}
+        </div>
+      ) : null}
+    </SurfaceCard>
+  );
+}

--- a/skills.md
+++ b/skills.md
@@ -29,10 +29,11 @@ Use the lead product engineer flow in the main thread to keep planning, sequenci
 ### Bug fix
 
 1. `explorer`
-2. `browser_debugger` when the flow is UI-facing
-3. relevant implementation agent
-4. `browser_screenshot` when the fix changes visible behavior
-5. `docs_writer` only when workflow or contributor guidance changes
+2. `design_guardian` when the fix is driven by visual QA, spacing, palette, typography, or layout review notes
+3. `browser_debugger` when the flow is UI-facing
+4. relevant implementation agent
+5. `browser_screenshot` when the fix changes visible behavior
+6. `docs_writer` only when workflow or contributor guidance changes
 
 ## Role Contracts
 
@@ -69,6 +70,7 @@ Fallback behavior:
 - Prefer Chrome MCP or another browser-native capture path.
 - Fall back to the existing screenshot skill only when browser-native capture is unavailable.
 - Treat screenshot capture as soft-required for frontend-affecting work. If the environment cannot access browser tooling, record the skip reason in the PR notes instead of blocking the branch.
+- If capture is blocked, interrupted, or times out, return a concrete skip reason immediately instead of waiting indefinitely.
 - For terminal, desktop-app, or agent-workflow fixes, capture equivalent terminal/app evidence with the screenshot skill and reference the artifact path in the PR notes.
 - Store captures in temp or other local artifacts; do not commit screenshots to the repo by default unless the task explicitly asks for a durable docs asset.
 
@@ -86,6 +88,7 @@ Update only the contributor-facing docs that changed. Keep extension notes conci
 - Record delegation evidence for non-trivial work: profile used, expected output, returned output, and any skip reason.
 - Ask each tracked profile to return changed files or inspected files, key risks, suggested tests, and artifact paths when UI evidence is expected.
 - If a tracked sub-agent is skipped for a non-trivial task, note the skip reason in the main thread instead of silently collapsing everything into one pass.
+- When a maintainer supplies manual UI review notes, treat them as explicit QA input, route them through `design_guardian` before implementation, and convert the accepted fixes into regression tests where feasible.
 - For backlog or issue-driven work in a dirty tree, compare the candidate issue against `HEAD` before assuming local WIP counts as issue progress.
 - Treat committed `HEAD` as the delivery baseline; do not count uncommitted local work as shipped progress.
 - Default to Issue Mode for branching. Only use Cycle Mode when the maintainer explicitly requests a shared branch with checkpoint commits per issue.

--- a/src/lib/toolkits.ts
+++ b/src/lib/toolkits.ts
@@ -15,11 +15,13 @@ export const toolkitRegistry: ToolkitDefinition[] = [
   {
     id: 'dataviz-toolkit',
     label: 'Data Visualization Toolkit',
-    summary: 'Structured chart workflows will launch here once the shared shell and toolkit contracts are in place.',
-    status: 'planned',
+    summary: 'Structured chart workflows with guided mapping, shared presets, and branded SVG/PNG export.',
+    href: '/dataviz-toolkit',
+    status: 'live',
     capabilities: [
       { id: 'dataviz-data', label: 'CSV / JSON' },
-      { id: 'dataviz-chart', label: 'Chart Templates' }
+      { id: 'dataviz-chart', label: 'Chart Templates' },
+      { id: 'dataviz-export', label: 'SVG / PNG' }
     ]
   },
   {

--- a/tests/chartRenderLayout.test.ts
+++ b/tests/chartRenderLayout.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { renderChartSvg } from '@packages/chart-core/src/renderSvg';
+
+const dataset = {
+  columns: ['Month', 'North', 'South', 'West'],
+  rows: [
+    { Month: 'Jan', North: '12', South: '9', West: '7' },
+    { Month: 'Feb', North: '18', South: '11', West: '10' },
+    { Month: 'Mar', North: '22', South: '16', West: '13' },
+    { Month: 'Apr', North: '28', South: '19', West: '17' }
+  ]
+};
+
+describe('renderChartSvg layout', () => {
+  it('wraps long subheadlines and renders the legend above the plot area', () => {
+    const chart = renderChartSvg({
+      dataset,
+      mapping: {
+        xColumn: 'Month',
+        yColumn: 'North',
+        valueColumns: ['North', 'South', 'West']
+      },
+      template: 'multi-line',
+      aspectRatio: '4:5',
+      headline: 'Ridership grew',
+      subheadline:
+        'This is a deliberately long subheadline that should wrap and shrink before it overflows outside the chart frame.',
+      source: 'Internal analytics',
+      themeId: 'dark-editorial',
+      options: {
+        showLegend: true
+      }
+    });
+
+    expect(chart.svg).toContain('<tspan');
+    expect(chart.svg).toContain('data-slot="legend"');
+    expect(chart.svg.indexOf('data-slot="legend"')).toBeLessThan(
+      chart.svg.indexOf('data-role="plot-line"')
+    );
+  });
+
+  it('always renders cartesian axes and y-axis tick labels for bar charts', () => {
+    const chart = renderChartSvg({
+      dataset,
+      mapping: {
+        xColumn: 'Month',
+        yColumn: 'North',
+        valueColumns: ['North']
+      },
+      template: 'bar',
+      aspectRatio: '4:5',
+      headline: 'Ridership grew',
+      subheadline: 'Morning recovered first',
+      source: 'Internal analytics',
+      themeId: 'dark-editorial'
+    });
+
+    expect(chart.svg).toContain('data-axis-group="cartesian"');
+    expect(chart.svg).toContain('data-axis-label="y"');
+    expect(chart.svg).toContain('data-axis-label="x"');
+  });
+
+  it('centers big numbers and honors custom palette overrides', () => {
+    const bigNumber = renderChartSvg({
+      dataset,
+      mapping: {
+        xColumn: 'Month',
+        yColumn: 'North',
+        valueColumns: ['North']
+      },
+      template: 'big-number',
+      aspectRatio: '1:1',
+      headline: 'Ridership grew',
+      subheadline: 'Morning recovered first',
+      source: 'Internal analytics',
+      themeId: 'dark-editorial'
+    });
+
+    expect(bigNumber.svg).toContain('data-role="big-number-value"');
+    expect(bigNumber.svg).toContain('text-anchor="middle"');
+
+    const barChart = renderChartSvg({
+      dataset,
+      mapping: {
+        xColumn: 'Month',
+        yColumn: 'North',
+        valueColumns: ['North']
+      },
+      template: 'bar',
+      aspectRatio: '1:1',
+      headline: 'Ridership grew',
+      subheadline: 'Morning recovered first',
+      source: 'Internal analytics',
+      themeId: 'dark-editorial',
+      options: {
+        useCustomPalette: true,
+        customPalette: ['orange']
+      }
+    });
+
+    expect(barChart.svg).toContain('fill="#FF7A00"');
+  });
+});

--- a/tests/chartValidation.test.ts
+++ b/tests/chartValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getDatavizValidationMessages } from '@packages/chart-core/src/validation';
+
+const dataset = {
+  columns: ['Month', 'North', 'South', 'Engagement'],
+  rows: [
+    { Month: 'Jan', North: '12', South: '9', Engagement: '0.42' },
+    { Month: 'Feb', North: '18', South: '14', Engagement: '0.53' }
+  ]
+};
+
+describe('dataviz validation', () => {
+  it('requires multiple series for grouped line templates', () => {
+    expect(
+      getDatavizValidationMessages({
+        dataset,
+        template: 'multi-line',
+        mapping: {
+          xColumn: 'Month',
+          yColumn: 'North',
+          valueColumns: ['North']
+        }
+      })
+    ).toContain('Choose at least two numeric series columns for this template.');
+  });
+
+  it('requires numeric x and y selections for scatter charts', () => {
+    expect(
+      getDatavizValidationMessages({
+        dataset,
+        template: 'scatter',
+        mapping: {
+          xColumn: 'Month',
+          yColumn: 'North',
+          valueColumns: ['North']
+        }
+      })
+    ).toContain('Scatter charts require a numeric X column.');
+  });
+});

--- a/tests/datavizToolkitPage.test.tsx
+++ b/tests/datavizToolkitPage.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DatavizToolkitPage } from '@apps/dataviz-toolkit/src/DatavizToolkitPage';
+
+describe('DatavizToolkitPage', () => {
+  it('renders inside the shared editor shell', () => {
+    render(<DatavizToolkitPage />);
+
+    expect(screen.getByRole('heading', { name: 'Data Visualization Toolkit' })).toBeInTheDocument();
+    expect(screen.getByTestId('editor-shell-panes')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-surface')).toBeInTheDocument();
+    expect(screen.getByLabelText('Output Preset')).toBeInTheDocument();
+  });
+
+  it('uses collapsible editor sections', () => {
+    render(<DatavizToolkitPage />);
+
+    const storyToggle = screen.getByRole('button', { name: 'Story' });
+    expect(storyToggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(storyToggle);
+
+    expect(storyToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByDisplayValue('Peak Hours Story')).not.toBeInTheDocument();
+  });
+});

--- a/tests/outputPresets.test.ts
+++ b/tests/outputPresets.test.ts
@@ -28,6 +28,11 @@ describe('output preset catalog', () => {
       height: 1350,
       class: 'image'
     });
+    expect(getOutputPreset('landscape-16x9')).toMatchObject({
+      width: 1920,
+      height: 1080,
+      class: 'image'
+    });
     expect(getOutputPreset('linkedin-shared-image')).toMatchObject({
       width: 1200,
       height: 627,
@@ -61,6 +66,6 @@ describe('output preset catalog', () => {
 
     const ratio = (linkedinPreset!.width / linkedinPreset!.height).toFixed(2);
     expect(Number(ratio)).toBe(1.91);
-    expect(listAllOutputPresets()).toHaveLength(8);
+    expect(listAllOutputPresets()).toHaveLength(9);
   });
 });

--- a/tests/toolkitContracts.test.ts
+++ b/tests/toolkitContracts.test.ts
@@ -16,7 +16,8 @@ describe('toolkit contracts', () => {
       aspectRatio: '4:5',
       export: {
         format: 'svg',
-        filename: 'ridership-story'
+        filename: 'ridership-story',
+        presetId: 'portrait-4x5'
       },
       presetMeta: {
         id: 'preset-1',
@@ -143,12 +144,24 @@ describe('toolkit contracts', () => {
       headline: 'Ridership grew',
       subheadline: 'Morning and evening recovered',
       source: 'Internal analytics',
-      themeId: 'dark-editorial'
+      themeId: 'dark-editorial',
+      annotations: ['North region outpaced plan'],
+      options: {
+        showGrid: true,
+        showLegend: true,
+        animate: false,
+        highlightSeries: 'North'
+      },
+      size: {
+        width: 1080,
+        height: 1350
+      }
     });
 
     expect(dataset.rows).toHaveLength(2);
     expect(chart.svg).toContain('<svg');
     expect(chart.svg).toContain('Ridership grew');
+    expect(chart.svg).toContain('North region outpaced plan');
   });
 
   it('ships themes that pass the configured contrast guidance', () => {

--- a/tests/toolkitLauncher.test.tsx
+++ b/tests/toolkitLauncher.test.tsx
@@ -19,7 +19,7 @@ describe('ToolkitLauncher', () => {
     expect(screen.getByText('Social Card Toolkit')).toBeInTheDocument();
   });
 
-  it('links only the live motion toolkit card', () => {
+  it('links the live motion and dataviz toolkits', () => {
     render(
       <ToolkitLauncher
         title="Brand Toolkit Suite"
@@ -30,8 +30,9 @@ describe('ToolkitLauncher', () => {
 
     const links = screen.getAllByRole('link');
 
-    expect(links).toHaveLength(1);
+    expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute('href', '/motion-toolkit/editor');
-    expect(screen.getAllByText('Planned')).toHaveLength(2);
+    expect(links[1]).toHaveAttribute('href', '/dataviz-toolkit');
+    expect(screen.getAllByText('Planned')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- ship the Cycle 2 Data Visualization Toolkit MVP on the shared shell
- polish the dataviz review findings: dropdown edit panes, fitted header typography, fixed legend placement, always-on cartesian axes, larger centered big-number layout, standard 4:5/16:9/1:1 presets, and editable palette overrides
- refine tracked skills and agent profiles for review-driven QA passes and immediate screenshot skip reasons

## Validation
- `npm run test:ci -- tests/chartValidation.test.ts tests/chartRenderLayout.test.ts tests/datavizToolkitPage.test.tsx tests/toolkitContracts.test.ts tests/toolkitLauncher.test.tsx tests/outputPresets.test.ts tests/configSchema.test.ts`
- `npm run build`
- Manual product review completed by maintainer; no separate screenshot artifact was attached in this pass

## Issues
- Closes #23
- Closes #24
- Closes #25
- Closes #26
- Closes #27
- Refs #15