### PR TITLE
GENGARVIS-035: document suite architecture and design cycle prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This changelog tracks notable repository changes. Add new entries to the topmost
 
 ### Changed
 
+- Refreshed `ROADMAP.md` for the `2026-03-19` Design Team cycle, including Cycle Mode branch/checkpoint planning for `#37`, `#38`, and `#33`, explicit `Input`/`Reason`/`Expected Outputs` review fields, and `CODEX` label expectations for reviewed issues.
+- Updated roadmap memory and workflow learnings to keep issue `#6` deferred through the shared preset decision in `#37` and to record the new Design Team cycle kickoff pattern.
+- Refreshed `README.md`, design decisions, and feature registry notes so the documented suite routes, shared package boundaries, shell contracts, and roadmap ownership match the current repo architecture.
 - Tracked sub-agent invocations renamed to unique DOTA hero names: explorer→slardar, design_guardian→omniknight, frontend_architect→tinker, chart_engine→kunkka, export_engine→gyrocopter, browser_debugger→bounty_hunter, browser_screenshot→sniper, openai_docs_researcher→oracle, docs_writer→clinkz. Updated `.codex/config.toml`, skills, roadmap, and workflow docs accordingly.
 - Updated contributor guidance and tests to reference `sniper` for screenshot evidence and `bounty_hunter` for interactive browser debugging.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ Browser-based internal platform for creating branded motion scenes, editorial da
 - `/dataviz-toolkit` structured chart generator
 - `/social-card-toolkit` constrained social card generator
 
+## Architecture Boundaries
+
+- `apps/` holds toolkit-specific app entrypoints and page-level composition.
+- `packages/design-tokens` defines shared color, typography, and brand-theme primitives.
+- `packages/config-schema` defines shared toolkit and document contracts.
+- `packages/export-engine` owns shared sizing and export helpers used by toolkit flows.
+- `packages/studio-shell` owns shared launcher, branded header, preview shell, output presets, and preset-storage helpers.
+- `packages/ui` holds reusable controls and layout primitives that toolkits should consume before inventing local variants.
+- `src/` remains the compatibility and app-integration surface for the current Motion Toolkit while shared packages are adopted incrementally.
+
+## Current Shared Contracts
+
+- Named output presets live in `packages/studio-shell` and cover social, LinkedIn, video, and print/PDF targets.
+- The Motion Toolkit remains the compatibility baseline for the suite and is routed through `/motion-toolkit/editor`, while `/editor` continues to redirect there.
+- Shared shell behavior uses a fixed preview pane with control-pane-owned overflow and scrolling.
+- Dataviz and Social Card Toolkit flows already consume shared package contracts for presets, export, theme, and shell behavior.
+- Deferred or under-specified feature ideas belong in `agent/memory/roadmap.md`; scheduled delivery sequencing lives in `ROADMAP.md`.
+
 ## Stack
 
 - Next.js App Router
@@ -65,5 +83,6 @@ npm run dev
 - Repo workflow skills, templates, and memory live under `agent/`.
 - Tracked Codex runtime delegation lives in `.codex/config.toml` and `agents/`.
 - Role definitions and delegation order live in `skills.md`.
+- Active delivery sequencing lives in `ROADMAP.md`; `agent/memory/roadmap.md` is reserved for deferred or unresolved feature ideas.
 - For frontend-affecting work, run a browser visual-validation pass before PR prep when browser tooling is available.
 - Screenshot artifacts should stay in temp or other local paths and be summarized in PR notes rather than committed by default.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-03-18
+Last updated: 2026-03-19
 
 This roadmap turns open feature issues into a reviewable delivery plan. Use it to sequence feature work, track dependencies, and record the multi-agent execution path for each issue.
 
@@ -8,7 +8,8 @@ This roadmap turns open feature issues into a reviewable delivery plan. Use it t
 
 ## Sources Of Truth
 
-- Open GitHub feature issues and epics: `#6`, `#14`-`#17`, `#18`-`#21`, `#23`-`#38`
+- Open GitHub issues reviewed on `2026-03-19`: `#6`, `#13`-`#18`, `#20`, `#28`-`#31`, `#33`-`#35`, `#37`
+- Closed design baseline reviewed on `2026-03-19`: `#38` (closed `2026-03-18`)
 - Previous handover plan: `/tmp/gengartoolkit-next-feature-workplan.md`
 - Multi-agent delegation guidance: `skills.md`
 - Backlog automation and roadmap routing: `agent/skills/run_backlog_cycle.md`
@@ -30,6 +31,8 @@ This roadmap turns open feature issues into a reviewable delivery plan. Use it t
 - Maintainer-directed combined PRs are allowed as narrow exceptions when commit boundaries stay explicit and the PR notes document the exception.
 - Use Cycle Mode only when a maintainer explicitly requests one shared delivery branch with checkpoint commits per issue.
 - Compare roadmap decisions against committed `HEAD`, not uncommitted local WIP.
+- For maintainer-directed cycle prep, record `Input`, `Reason`, `Expected Outputs`, tracked agent handoffs, and `CODEX` label status before implementation starts.
+- Apply the `CODEX` label to every open issue reviewed during a Codex-run cycle planning pass, even when the issue stays out of scope for the active branch.
 - Update `CHANGELOG.md` for shipped work.
 - For frontend-affecting work, capture browser QA artifacts or record a concrete skip reason.
 - When work is too broad or unclear, defer it to `agent/memory/roadmap.md` instead of guessing.
@@ -51,6 +54,88 @@ This roadmap turns open feature issues into a reviewable delivery plan. Use it t
 - Screenshot artifact paths for frontend-visible changes when browser tooling is available
 - Changelog entry
 - Issue comment with summary, validation notes, and PR link when work is review-ready
+
+## Active Cycle Prep
+
+### Design Team Cycle — 2026-03-19
+
+Goal: run one Design Team sprint that converts the already-merged shared preset and shell groundwork into a clear implementation stream for named output selection and shared brand guardrails while consuming the closed `#38` shell contract as the UI baseline.
+
+- `Branch`: `codex/GENGARVIS-037-cycle-design-team`
+- `Mode`: `Cycle Mode`
+- `Baseline`: local `main` was synced to `origin/main` at `776786a` before the cycle branch was created
+- `Checkpoint Order`:
+  1. `#37` finalize named output preset adoption
+  2. validate and extend the closed `#38` shell baseline only where `#37` or `#33` require it
+  3. `#33` add shared brand guardrail warnings, then export gating for hard failures
+- `Reviewed Issues`: open issues `#6`, `#13`-`#18`, `#20`, `#28`-`#31`, `#33`-`#35`, `#37`, plus closed issue `#38` as design baseline input
+- `CODEX Label Policy`: required on every reviewed open issue in this cycle-prep pass
+
+#### In Scope
+
+- `#37` Create shared output preset catalog for social, LinkedIn, and print formats — `Planned`
+  - `Input`: existing `packages/studio-shell` output preset catalog, current Motion Toolkit export and selector flow, shared export-sizing helpers, issue `#6`, and the merged changelog notes that preset groundwork already exists on `main`
+  - `Reason`: named output presets need to become the source of truth before shell adoption or guardrails can safely depend on them
+  - `Expected Outputs`: named preset selection by output class, one sizing source of truth for preview and export, preserved `300 DPI` metadata for PDF-class presets, and compatibility mapping from legacy aspect-ratio paths during the migration window
+  - `Agents`: `slardar`, `omniknight`, `tinker`, `bounty_hunter`, `sniper`, `clinkz`
+  - `Dependencies`: `#19`, `#20`, `#21`, `#32`
+  - `Evidence`: preset catalog tests, selector integration coverage, export-dimension assertions, and screenshot proof of the preset-selection flow
+  - `CODEX Label`: required and applied
+  - `Next Step`: checkpoint 1 commit on the cycle branch
+- `#33` Shared brand guardrail validation — `Planned`
+  - `Input`: approved design tokens, shared theme utilities, the finalized preset and shell decisions from `#37` and `#38`, and the existing validation patterns already used by dataviz
+  - `Reason`: shared brand guardrails should attach to the settled design system, not compete with it while core shell and preset semantics are still moving
+  - `Expected Outputs`: shared guardrail utilities, readable warning UI for non-designer users, export blocking only for hard failures, and compatibility with both token defaults and custom HEX fallback during the rollout window
+  - `Agents`: `slardar`, `omniknight`, `tinker`, `bounty_hunter`, `sniper`, `clinkz`
+  - `Dependencies`: `#19`, `#20`, `#37`, `#38`
+  - `Evidence`: unit coverage for guardrail rules, one export-block integration test, and screenshot proof of warning and blocked-export states
+  - `CODEX Label`: required and applied
+  - `Next Step`: checkpoint 3 commit after the preset and shell slices are stable on the cycle branch
+
+#### Closed Baseline Consumed By This Cycle
+
+- `#38` Standardize toolkit editor shell with fitted preview and palette-first controls — `Closed on 2026-03-18`
+  - `Input`: `packages/studio-shell` shell primitives, merged preview-stability work in `CHANGELOG.md`, palette-grid groundwork, and the existing control-density tests already on `main`
+  - `Reason`: the Design Team cycle should consume the closed shell contract instead of reopening the issue or duplicating toolkit-local shell work
+  - `Expected Outputs`: `#37` and `#33` must reuse the shipped two-pane shell, fitted preview behavior, branded header, and palette-first control model instead of inventing replacements
+  - `Agents`: `slardar`, `omniknight`, `tinker`, `bounty_hunter`, `sniper`
+  - `Evidence`: shell regression coverage and screenshot validation should prove the closed baseline still holds while the active cycle lands follow-through changes
+  - `CODEX Label`: applied before close and retained for tracker continuity
+  - `Next Step`: treat as required baseline during checkpoints 1 through 3
+
+#### Out Of Scope For This Cycle
+
+- `#6` Adjust Square and 4x5 Text to Size ratio — reviewed and intentionally deferred through `#37` so typography scaling does not fork into a motion-only rule set
+- `#34` Regression coverage for preview/export parity — reviewed, but only direct regression tests required by `#37` or `#38` should land in this cycle; the broader hardening sweep stays for a later pass
+- `#35` Update changelog and agent memory for suite architecture — reviewed and deferred as a full docs sweep until the Design Team cycle lands real behavior changes
+- `#18` and `#20` — reviewed as upstream references already present on `main`; do not reopen package-boundary work inside this cycle branch
+- `#14`, `#15`, `#16`, and `#17` — reviewed as planning epics only; they inform the cycle but are not active implementation slices
+- `#28`, `#29`, `#30`, and `#31` — reviewed as downstream social-card work that should wait for the preset and shell contracts coming out of this cycle
+- `#13` Screenshot helper can target the wrong iTerm Codex session — reviewed and left separate because it is a workflow bug, not part of the Design Team sprint
+
+#### Sub-Agent Handoff
+
+- `slardar`
+  - Confirm the committed `main` baseline, identify the smallest safe change set for each checkpoint, and flag any sizing/schema/export compatibility traps before edits start
+  - Return inspected files, reuse seams, and risk notes for `#37`, `#38`, and `#33`
+- `omniknight`
+  - Lock preset naming, shell composition, palette-first interaction rules, warning copy, and guardrail thresholds before implementation
+  - Return acceptance bullets, token usage notes, and any visual constraints that must stay shared
+- `tinker`
+  - Own the cycle branch implementation in checkpoint order, reusing shared shell and preset primitives instead of introducing toolkit-local patterns
+  - Return changed files, test impact, and any follow-up slices that should stay out of scope
+- `bounty_hunter`
+  - Validate md/lg breakpoints, preview/export parity, console cleanliness, and visible regressions after each checkpoint
+  - Return repro notes, findings, and the smallest-fix suggestions when QA fails
+- `sniper`
+  - Capture PR-ready artifacts for preset selection, standardized shell layout, palette-first flow, and guardrail warning/export-block states
+  - Return artifact paths, what each artifact proves, and an immediate skip reason if browser capture is blocked
+- `clinkz`
+  - Keep `CHANGELOG.md`, issue updates, and any contributor-facing notes aligned with the actual cycle slices that land
+  - Return changed files plus the short issue-summary text that should accompany review-ready work
+- `oracle`, `kunkka`, `gyrocopter`
+  - Skip by default for this cycle
+  - Activate only if the scope expands into current OpenAI/MCP behavior, chart-template work, or export-engine changes beyond preset adoption
 
 ## Delivery Sequence
 
@@ -129,12 +214,17 @@ Goal: stabilize suite behavior once the shared foundations and toolkit slices ar
 Use this structure when an item moves from roadmap review into active implementation:
 
 - `Issue`: `#NN` title
+- `Scope`: `In Scope` or `Out Of Scope`
 - `Status`: one item from the status legend
 - `Branch`: `codex/GENGARVIS-###-short-slug`
+- `Input`: repo state, issue body, prior roadmap/changelog notes, and upstream dependencies that the implementation must honor
+- `Reason`: why the issue is shipping now or why it is explicitly deferred
+- `Expected Outputs`: 2-5 outcome bullets that define the intended implementation boundary
 - `Agents`: tracked profiles used, in order
 - `Dependencies`: upstream issues or packages
 - `Acceptance`: 2-5 outcome bullets
 - `Evidence`: tests, screenshot artifact paths, PR link
+- `CODEX Label`: required status plus whether the label is already applied
 - `Next Step`: the immediate implementation action
 
 ## Dependency Notes
@@ -151,3 +241,4 @@ Use this structure when an item moves from roadmap review into active implementa
 - `2026-03-15`: Created the root roadmap from the open feature queue, the current agent workflow rules, and the handover plan at `/tmp/gengartoolkit-next-feature-workplan.md`.
 - `2026-03-16`: Updated Cycle 1 items to review status after the shared package, motion-route, preset-catalog, and shell-groundwork commits were stacked on the cycle branch.
 - `2026-03-18`: Recorded the current branch’s preview-stability, fixed-pane shell, and single-active controls behavior under `#38`, plus the supporting regression-hardening progress under `#34`.
+- `2026-03-19`: Synced local `main` to `origin/main`, created `codex/GENGARVIS-037-cycle-design-team`, and added an explicit Design Team cycle-prep section with in-scope/out-of-scope review fields, checkpoint order, and tracked sub-agent handoffs.

--- a/agent/memory/design_decisions.md
+++ b/agent/memory/design_decisions.md
@@ -23,6 +23,9 @@
 - The repository now exposes a Brand Toolkit Suite with toolkit-specific entry points rather than a single top-level editor landing page.
 - Shared contracts are introduced through `apps/` and `packages/` boundaries first, while the existing motion editor remains behaviorally stable at `/motion-toolkit/editor`.
 - New toolkits use shared package contracts for themes, schema, chart/export logic, and shell UI before any deeper package manager or multi-runtime workspace split.
+- `packages/studio-shell` is the shared home for launcher, branded shell, preview behavior, preset storage, and named output preset contracts.
+- `packages/ui` is the preferred reuse layer for controls and layout primitives; toolkit-local UI should be the exception rather than the default.
+- Root `ROADMAP.md` is the source of truth for scheduled delivery sequencing, while `agent/memory/roadmap.md` remains the holding area for valid but unresolved feature ideas.
 
 ## Agent Layer
 

--- a/agent/memory/feature_registry.md
+++ b/agent/memory/feature_registry.md
@@ -10,6 +10,8 @@
 
 - Platform launcher for Motion Toolkit, Data Visualization Toolkit, and Social Card Toolkit
 - Shared toolkit registry, export-capability contracts, and package-style platform boundaries
+- Shared studio-shell primitives for branded headers, preview layouts, output presets, and preset storage
+- Shared UI primitives for palette-first controls, collapsible control sections, and reusable editor surfaces
 
 ## Data Visualization Toolkit
 
@@ -41,6 +43,7 @@
 ## Preset System
 
 - Default presets and local preset persistence built on the editor store.
+- Shared version-aware preset storage helpers used across toolkit flows.
 
 ## Export
 

--- a/agent/memory/roadmap.md
+++ b/agent/memory/roadmap.md
@@ -17,7 +17,7 @@ Active delivery sequencing now lives in the root `ROADMAP.md`.
 ## Next
 
 - Issue #6: Adjust Square and 4x5 Text to Size ratio
-  Valid feature request, but it changes typography scaling semantics across formats and should route through the shared output preset work in issue `#37` instead of shipping as a one-off motion tweak.
+  Valid feature request, re-reviewed during the `2026-03-19` Design Team cycle prep, but it still changes typography scaling semantics across formats and should route through the shared output preset work in issue `#37` instead of shipping as a one-off motion tweak.
 
 ## Later
 
@@ -25,4 +25,5 @@ Active delivery sequencing now lives in the root `ROADMAP.md`.
 
 ## Needs Discussion
 
-- Decide whether typography size controls should map to a normalized visual scale, a format-aware multiplier, or preset-specific defaults before implementing issue #6.
+- Decide whether typography size controls should map to a normalized visual scale, a format-aware multiplier, or preset-specific defaults before implementing issue `#6`.
+- Revisit issue `#6` only after the Design Team cycle settles the named output preset contract in `#37`.

--- a/agent/memory/workflow_learnings.md
+++ b/agent/memory/workflow_learnings.md
@@ -1,5 +1,37 @@
 # Workflow Learnings
 
+## Issue 37/38/33: Design Team Cycle Prep
+
+### What Worked
+
+- Syncing local `main` to `origin/main` before creating the cycle branch removed ambiguity about which groundwork was already merged.
+- Converting the cycle review into explicit `Input`, `Reason`, and `Expected Outputs` fields made the in-scope versus out-of-scope decision easier to audit.
+- Writing sub-agent ownership into the roadmap upfront reduced the chance of overlapping implementation, QA, and docs work once the cycle starts.
+
+### What Slowed Us Down
+
+- The roadmap still mixed already-merged groundwork with upcoming follow-through work, so the active cycle boundary had to be restated before execution could start.
+- Several reviewed issues were still missing the `CODEX` label, which made cycle tracking inconsistent until the label pass was added to the prep checklist.
+
+### Skill Updates Needed
+
+- `run_backlog_cycle` should support a maintainer-directed mode where all reviewed issues, not just the in-scope ones, are marked for `CODEX` tracking.
+- Roadmap templates should keep `Input`, `Reason`, `Expected Outputs`, and agent handoff fields available for future cycle-prep passes.
+
+### Workflow Updates Needed
+
+- Always fetch and fast-forward `main` before opening a new Cycle Mode branch.
+- Record `CODEX` label coverage as a first-class cycle kickoff step.
+- Keep checkpoint order and sub-agent ownership in the roadmap so the branch can be resumed without re-planning.
+
+### Reusable Delivery Pattern
+
+1. Sync `main` against the remote before deciding cycle scope.
+2. Review the live open issue set instead of relying on the previous roadmap snapshot.
+3. Lock in-scope items with `Input`, `Reason`, `Expected Outputs`, and handoff ownership before implementation starts.
+4. Label every reviewed issue consistently so planning and delivery use the same tracker state.
+5. Create the shared cycle branch only after the roadmap reflects the real baseline.
+
 ## Issue 1: Preview vs Export Typography Parity
 
 ### What Worked


### PR DESCRIPTION
Summary:
- refresh suite documentation so README, roadmap, changelog, and agent memory reflect the current repo architecture
- record the 2026-03-19 Design Team cycle scope, out-of-scope decisions, checkpoint order, and sub-agent handoffs
- align tracker state by applying the CODEX label across the reviewed open issue set

Validation:
- not run; docs and GitHub-tracker updates only
- verified open issue CODEX label coverage via gh issue list search
- verified that issue #38 is closed and should be treated as baseline input

Notes:
- frontend visual QA not applicable for this doc-only PR

Closes #35